### PR TITLE
UNO memory and Compiler warnings

### DIFF
--- a/objdump.bat
+++ b/objdump.bat
@@ -1,0 +1,14 @@
+ECHO ON
+FOR /F "delims=" %%i IN ('dir %TMP%\arduino_build_* /b /ad-h /t:c /od') DO SET a=%%i
+echo Most recent subfolder: %a% >%TMP%\OBJDUMP_%a%.txt
+avr-objdump --private=mem-usage  %TMP%\%a%\CommandStation-EX.ino.elf  >>%TMP%\OBJDUMP_%a%.txt
+ECHO ++++++++++++++++++++++++++++++++++ >>%TMP%\OBJDUMP_%a%.txt
+avr-objdump -x -C %TMP%\%a%\CommandStation-EX.ino.elf | find ".text" | sort /+25 /R >>%TMP%\OBJDUMP_%a%.txt
+ECHO ++++++++++++++++++++++++++++++++++ >>%TMP%\OBJDUMP_%a%.txt
+avr-objdump -x -C %TMP%\%a%\CommandStation-EX.ino.elf | find ".data" | sort /+25 /R >>%TMP%\OBJDUMP_%a%.txt
+ECHO ++++++++++++++++++++++++++++++++++ >>%TMP%\OBJDUMP_%a%.txt
+avr-objdump -x -C %TMP%\%a%\CommandStation-EX.ino.elf | find ".bss" | sort /+25 /R >>%TMP%\OBJDUMP_%a%.txt
+ECHO ++++++++++++++++++++++++++++++++++ >>%TMP%\OBJDUMP_%a%.txt
+avr-objdump -d -S -C %TMP%\%a%\CommandStation-EX.ino.elf  >>%TMP%\OBJDUMP_%a%.txt
+notepad %TMP%\OBJDUMP_%a%.txt
+EXIT

--- a/src/CommInterface/CommManager.h
+++ b/src/CommInterface/CommManager.h
@@ -48,7 +48,7 @@ public:
   static void showInitInfo();
   static void broadcast(const __FlashStringHelper* input, ...);
   static void print(const __FlashStringHelper* input, ...);
-  static void doNotPrint(const __FlashStringHelper* input, ...) {}
+  static void doNotPrint(const __FlashStringHelper* input, ...) { (void)input;}
   static void send(Print* stream, const __FlashStringHelper* input, ...);
   static void printEscapes(Print* stream, char * input);
   static void printEscapes(Print* stream, const __FlashStringHelper* input);

--- a/src/DCC/DCC.h
+++ b/src/DCC/DCC.h
@@ -77,7 +77,9 @@ enum PacketType : uint8_t {
   kSrvcReadType
 };
 
+#ifndef ARDUINO_AVR_UNO
 extern const uint8_t railcom_decode[256];
+#endif 
 
 // invalid value (not conforming to the 4bit weighting requirement)
 const uint8_t INV = 0xFF;
@@ -255,8 +257,10 @@ public:
     
     if(board->getProgMode()) // If we're in programming mode
       ackManagerLoop();
+#ifndef ARDUINO_AVR_UNO      
     else
       rcomProcessData(board->rcomBuffer, rcomID, rcomTxType, rcomAddr);
+      #endif
   }
 
   Board* board;

--- a/src/DCC/RailCom.cpp
+++ b/src/DCC/RailCom.cpp
@@ -21,6 +21,8 @@
 
 #include <avr/pgmspace.h>
 
+#ifndef ARDUINO_AVR_UNO
+
 const uint8_t railcom_decode[256] PROGMEM =
 {    INV,    INV,    INV,    INV,    INV,    INV,    INV,    INV,
      INV,    INV,    INV,    INV,    INV,    INV,    INV,   NACK,
@@ -192,3 +194,4 @@ CLEANUP:
     data[i] = 0x00;
   }
 }
+#endif


### PR DESCRIPTION
REmoves compiler warning in doNotPrint.

Removes Railcom proxcessing on a UNO compiler