### PR TITLE
Fix Wifi <> language

### DIFF
--- a/src/CommInterface/DCCEXParser.cpp
+++ b/src/CommInterface/DCCEXParser.cpp
@@ -94,6 +94,8 @@ int DCCEXParser::stringParser(const char *com, int result[]) {
 
 // See documentation on DCC class for info on this section
 void DCCEXParser::parse(Print* stream, const char *com) {
+  if (com[0]=='<') com++;
+
   int numArgs = stringParser(com+1, p);
   
   switch(com[0]) {


### PR DESCRIPTION
WiThrottlse passed commands with '<' prefix to DCCEXParser... 
Could have changed Withrottle... instead but .... whaetever
 