### PR TITLE
V fixes, R command and github sha.

### DIFF
--- a/DCCEXParser.h
+++ b/DCCEXParser.h
@@ -55,6 +55,7 @@ struct DCCEXParser
     static void callback_W(int result);
     static void callback_B(int result);        
     static void callback_R(int result);
+    static void callback_Rloco(int result);
     static void callback_Vbit(int result);
     static void callback_Vbyte(int result);
     static FILTER_CALLBACK  filterCallback;

--- a/GITHUB_SHA.h
+++ b/GITHUB_SHA.h
@@ -1,0 +1,1 @@
+#define GITHUB_SHA "9db6d36"


### PR DESCRIPTION
Fixes fault in <V> command whereby an invalid number of parameters can leave the ack manager locked.
Adds <R> commadn (no params) to read loco id.
Adds GITHUB_SHA facility (automated git action to follow) 