### PR TITLE
RMFT Hooks

### DIFF
--- a/CommandStation-EX.ino
+++ b/CommandStation-EX.ino
@@ -53,6 +53,11 @@ void setup()
   // waveform generation.  e.g.  DCC::begin(STANDARD_MOTOR_SHIELD,2); to use timer 2
 
   DCC::begin(MOTOR_SHIELD_TYPE); 
+  
+  #if defined(RMFT_ACTIVE) 
+      RMFT::begin();
+  #endif
+      
   LCD(1,F("Ready")); 
 }
 
@@ -73,6 +78,10 @@ void loop()
 #endif
 #if ETHERNET_ON
   EthernetInterface::loop();
+#endif
+
+#if defined(RMFT_ACTIVE) 
+  RMFT::loop();
 #endif
 
   LCDDisplay::loop();  // ignored if LCD not in use 

--- a/DCCEX.h
+++ b/DCCEX.h
@@ -15,6 +15,10 @@
 #endif
 #include "LCD_Implementation.h"
 #include "freeMemory.h"
-#include <Arduino.h>
 
+#if __has_include ( "myAutomation.h")
+  #include "RMFT.h"
+  #define RMFT_ACTIVE
+#endif
+    
 #endif

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -221,10 +221,15 @@ int DCCEXParser::splitHexValues(int result[MAX_PARAMS], const byte *cmd)
 }
 
 FILTER_CALLBACK DCCEXParser::filterCallback = 0;
+FILTER_CALLBACK DCCEXParser::filterRMFTCallback = 0;
 AT_COMMAND_CALLBACK DCCEXParser::atCommandCallback = 0;
 void DCCEXParser::setFilter(FILTER_CALLBACK filter)
 {
     filterCallback = filter;
+}
+void DCCEXParser::setRMFTFilter(FILTER_CALLBACK filter)
+{
+    filterRMFTCallback = filter;
 }
 void DCCEXParser::setAtCommandCallback(AT_COMMAND_CALLBACK callback)
 {
@@ -245,6 +250,8 @@ void DCCEXParser::parse(Print *stream, byte *com, bool blocking)
 
     if (filterCallback)
         filterCallback(stream, opcode, params, p);
+    if (filterRMFTCallback && opcode!='\0')
+        filterRMFTCallback(stream, opcode, params, p);
 
     // Functions return from this switch if complete, break from switch implies error <X> to send
     switch (opcode)

--- a/DCCEXParser.h
+++ b/DCCEXParser.h
@@ -30,6 +30,7 @@ struct DCCEXParser
    void parse(Print * stream,  byte * command, bool blocking);
    void flush();
    static void setFilter(FILTER_CALLBACK filter);
+   static void setRMFTFilter(FILTER_CALLBACK filter);
    static void setAtCommandCallback(AT_COMMAND_CALLBACK filter);
    static const int MAX_PARAMS=10;  // Must not exceed this
  
@@ -61,6 +62,7 @@ struct DCCEXParser
     static void callback_Vbit(int result);
     static void callback_Vbyte(int result);
     static FILTER_CALLBACK  filterCallback;
+    static FILTER_CALLBACK  filterRMFTCallback;
     static AT_COMMAND_CALLBACK  atCommandCallback;
     static void funcmap(int cab, byte value, byte fstart, byte fstop);
 


### PR DESCRIPTION
These hooks do NOT require RMFT code to be present.... but they offer the hooks that RMFT will need when available. This is in preparation for adding train automation scripting capability to DCC-EX. The name "RMFT" will probably change in the future.