### PR TITLE
Nano every2 tweaks

### DIFF
--- a/LCDDisplay.h
+++ b/LCDDisplay.h
@@ -20,12 +20,21 @@
 #define LCDDisplay_h
 #include <Arduino.h>
 
+#if __has_include ( "config.h")
+  #include "config.h"
+#endif
+
+// Allow maximum message length to be overridden from config.h
+#if !defined(MAX_MSG_SIZE) 
+#define MAX_MSG_SIZE 16
+#endif
+
 // This class is created in LCDisplay_Implementation.h
 
 class LCDDisplay : public Print {
  public:
   static const int MAX_LCD_ROWS = 8;
-  static const int MAX_LCD_COLS = 16;
+  static const int MAX_LCD_COLS = MAX_MSG_SIZE;
   static const long LCD_SCROLL_TIME = 3000;  // 3 seconds
 
   static LCDDisplay* lcdDisplay;
@@ -43,6 +52,7 @@ class LCDDisplay : public Print {
 
  private:
   void moveToNextRow();
+  void skipBlankRows();
 
   // Relay functions to the live driver
   void clearNative();
@@ -64,7 +74,6 @@ class LCDDisplay : public Print {
   char* bufferPointer = 0;
   bool done = false;
 
-  void renderRow(byte row);
   char rowBuffer[MAX_LCD_ROWS][MAX_LCD_COLS + 1];
 };
 


### PR DESCRIPTION
Fix situation where page scrolling (SCROLLMODE 1) can cause a blank screen to be displayed.

Also, allow a builder to configure the maximum message length for LCD/OLED display.  Then if they want to create longer messages for some reason, they can take advantage of the 20 or 21 characters available on an LCD2004 or OLED (at the expense of using more RAM for message buffers).  Messages in the standard build should be maintained at 16 characters which is the default max message length, to ensure compatibility with LCD1602 screens.  This therefore has no impact on current program size or ram usage unless activated.  Also, since the messages are written to the screen one character per loop entry, the maximum loop time will be unaffected.