### PR TITLE
ED driveaway

### DIFF
--- a/WiThrottle.cpp
+++ b/WiThrottle.cpp
@@ -248,7 +248,7 @@ void WiThrottle::multithrottle(RingStream * stream, byte * cmd){
                     //Get known Fn states from DCC 
                     for(int fKey=0; fKey<=28; fKey++) { 
                       int fstate=DCC::getFn(locoid,fKey);
-                      if (fstate>=0) StringFormatter::send(stream,F("M%cA%c<;>F%d%d\n"),throttleChar,cmd[3],fstate,fKey);
+                        if (fstate>=0) StringFormatter::send(stream,F("M%cA%c%d<;>F%d%d\n"),throttleChar,cmd[3],locoid,fstate,fKey);                     
                     }
                     StringFormatter::send(stream, F("M%cA%c%d<;>V%d\n"), throttleChar, cmd[3], locoid, DCCToWiTSpeed(DCC::getThrottleSpeed(locoid)));
                     StringFormatter::send(stream, F("M%cA%c%d<;>R%d\n"), throttleChar, cmd[3], locoid, DCC::getThrottleDirection(locoid));

--- a/WiThrottle.h
+++ b/WiThrottle.h
@@ -60,6 +60,14 @@ class WiThrottle {
       void multithrottle(RingStream * stream, byte * cmd);
       void locoAction(RingStream * stream, byte* aval, char throttleChar, int cab);
       void accessory(RingStream *, byte* cmd);
-      void checkHeartbeat();  
+      void checkHeartbeat(); 
+
+       // callback stuff to support prog track acquire
+       static RingStream * stashStream;
+       static WiThrottle * stashInstance;
+       static byte         stashClient;
+       static char         stashThrottleChar;
+       static void         getLocoCallback(int locoid);
+
 };
 #endif


### PR DESCRIPTION
Allows EngineDriver to acquire loco from prog track and drive it away.

Also automatically undoes a < 1 JOIN > if any prog track commands issued.