### PR TITLE
Ensure loop2() doesn't run during initialisation if there's no display.

### DIFF
--- a/LCDDisplay.cpp
+++ b/LCDDisplay.cpp
@@ -72,6 +72,7 @@ void LCDDisplay::loop() {
 }
 
 LCDDisplay *LCDDisplay::loop2(bool force) {
+  if (!lcdDisplay) return NULL;
   unsigned long currentMillis = millis();
 
   if (!force) {


### PR DESCRIPTION
Prevent loop2 from doing anything when lcdDisplay not set up.  If there's a display configured but not one attached, then the OLED code will set lcdDisplay to null and no display will be configured or used by the loop() function.  However, because of the way the initialisation code works, loop2() is called during initialisation.