### PR TITLE
Fix turnout handling of EEPROM

### DIFF
--- a/Turnouts.h
+++ b/Turnouts.h
@@ -54,6 +54,8 @@ class Turnout {
 #ifdef EESTOREDEBUG
   void print(Turnout *tt);
 #endif
+private:
+  int num;  // EEPROM address of tStatus in TurnoutData struct, or zero if not stored.
 }; // Turnout
   
 #endif


### PR DESCRIPTION
On switching, Turnout code was saving entire EEPROM twice, even if EEPROM save had been turned off with the `<e>` command.
It's now been changed so that, after switching of the Turnout, only the tStatus byte is updated (once), and only if the turnout has previously been saved into EEPROM.  This is more like the code for the Outputs and for the original DCC++, but more resilient.

I've performed the following tests:
1) Cleared EEPROM, created turnout and saved to EEPROM:  `<e> <T 1 0 0> <E>`
2) Reset CS and checked that the turnout has been recreated:  `reset, <T>  (responds <H 1 0 0 0>)`
3) Switch turnout, reset and check that turnout state was updated: `<T 1 1>, reset, <T> (responds <H 1 0 0 1>)`
4) Cleared EEPROM, switch turnout and check: `<e> <T 1 0> <T> (responds <H 1 0 0 0>)`
5) Reset CS and check turnout is not present: `reset, <T> (responds <X>)`

Incidentally, prior to this change I was seeing turnout activations taking more than 28,000us to complete (because of the sledgehammer EEPROM writes).  Now it takes much less than the normal loop time (not measurable) whether updating the one byte of EEPROM or not.  I expected to see around 3300us time to write one byte but the maximum loop time does not increase when the turnout EEPROM state is updated.