### PR TITLE
Fix auto rejoin after prog cmd (needs version n umber!)

### DIFF
--- a/DCC.cpp
+++ b/DCC.cpp
@@ -710,6 +710,7 @@ void  DCC::ackManagerSetup(int cv, byte byteValueOrBitnum, ackOp const program[]
       
    DCCWaveform::progTrack.autoPowerOff=false;           
    if (DCCWaveform::progTrack.getPowerMode() == POWERMODE::OFF) {
+        DCCWaveform::progTrack.autoPowerOff=true;  // power off afterwards           
         if (Diag::ACK) DIAG(F("Auto Prog power on"));
         DCCWaveform::progTrack.setPowerMode(POWERMODE::ON);
         DCCWaveform::progTrack.sentResetsSincePacket = 0;      

--- a/DCC.cpp
+++ b/DCC.cpp
@@ -691,6 +691,8 @@ byte   DCC::ackManagerBitNum;
 bool   DCC::ackReceived;
 bool   DCC::ackManagerRejoin;
 
+CALLBACK_STATE DCC::callbackState=READY;
+
 ACK_CALLBACK DCC::ackManagerCallback;
 
 void  DCC::ackManagerSetup(int cv, byte byteValueOrBitnum, ackOp const program[], ACK_CALLBACK callback) {
@@ -743,6 +745,7 @@ void DCC::ackManagerLoop() {
       case BASELINE:
       	  if (checkResets(DCCWaveform::progTrack.autoPowerOff || ackManagerRejoin  ? 20 : 3)) return;
           DCCWaveform::progTrack.setAckBaseline();
+          callbackState=READY;
           break;   
       case W0:    // write 0 bit 
       case W1:    // write 1 bit 
@@ -753,6 +756,7 @@ void DCC::ackManagerLoop() {
               byte message[] = {cv1(BIT_MANIPULATE, ackManagerCv), cv2(ackManagerCv), instruction };
               DCCWaveform::progTrack.schedulePacket(message, sizeof(message), PROG_REPEATS);
               DCCWaveform::progTrack.setAckPending(); 
+             callbackState=AFTER_WRITE;
          }
             break; 
       
@@ -763,6 +767,7 @@ void DCC::ackManagerLoop() {
               byte message[] = {cv1(WRITE_BYTE, ackManagerCv), cv2(ackManagerCv), ackManagerByte};
               DCCWaveform::progTrack.schedulePacket(message, sizeof(message), PROG_REPEATS);
               DCCWaveform::progTrack.setAckPending(); 
+              callbackState=AFTER_WRITE;
             }
             break;
       
@@ -893,24 +898,61 @@ void DCC::ackManagerLoop() {
     ackManagerProg++;
   }
 }
-void DCC::callback(int value) {
-    ackManagerProg=NULL;  // no more steps to execute
-    if (DCCWaveform::progTrack.autoPowerOff) {
-      if (Diag::ACK) DIAG(F("Auto Prog power off"));
-      DCCWaveform::progTrack.doAutoPowerOff();
-    }
 
-    // Restore <1 JOIN> to state before BASELINE
-    if (ackManagerRejoin) {
-      setProgTrackSyncMain(true);
-      if (Diag::ACK) DIAG(F("Auto JOIN"));
-    }  
+void DCC::callback(int value) {
+    static unsigned long callbackStart;
+    // We are about to leave programming mode
+    // Rule 1: If we have written to a decoder we must maintain power for 100mS
+    // Rule 2: If we are re-joining the main track we must power off for 30mS
+
+    switch (callbackState) {    
+       case AFTER_WRITE:  // first attempt to callback after a write operation
+            callbackStart=millis();
+            callbackState=WAITING_100;
+            if (Diag::ACK) DIAG(F("Stable 100mS"));
+            break;
+            
+       case WAITING_100:  // waiting for 100mS
+            if (millis()-callbackStart < 100) break;
+            // stable after power maintained for 100mS
+
+            // If we are going to power off anyway, it doesnt matter
+            // but if we will keep the power on, we must off it for 30mS
+            if (DCCWaveform::progTrack.autoPowerOff) callbackState=READY;
+            else { // Need to cycle power off and on
+                DCCWaveform::progTrack.setPowerMode(POWERMODE::OFF); 
+                callbackStart=millis();
+                callbackState=WAITING_30;
+                if (Diag::ACK) DIAG(F("OFF 30mS"));
+            }
+            break;
+ 
+        case WAITING_30:  // waiting for 30mS with power off
+            if (millis()-callbackStart < 30) break;
+            //power has been off for 30mS
+            DCCWaveform::progTrack.setPowerMode(POWERMODE::ON); 
+            callbackState=READY;
+            break;
+     
+       case READY:  // ready after read, or write after power delay and off period.
+            // power off if we powered it on
+           if (DCCWaveform::progTrack.autoPowerOff) {
+              if (Diag::ACK) DIAG(F("Auto Prog power off"));
+              DCCWaveform::progTrack.doAutoPowerOff();
+           }
+          // Restore <1 JOIN> to state before BASELINE
+          if (ackManagerRejoin) {
+              setProgTrackSyncMain(true);
+              if (Diag::ACK) DIAG(F("Auto JOIN"));
+          }  
     
-    if (Diag::ACK) DIAG(F("Callback(%d)"),value);
-    (ackManagerCallback)( value);
+          ackManagerProg=NULL;  // no more steps to execute
+          if (Diag::ACK) DIAG(F("Callback(%d)"),value);
+          (ackManagerCallback)( value);
+    }
 }
 
- void DCC::displayCabList(Print * stream) {
+void DCC::displayCabList(Print * stream) {
 
     int used=0;
     for (int reg = 0; reg < MAX_LOCOS; reg++) {

--- a/DCC.h
+++ b/DCC.h
@@ -54,6 +54,14 @@ enum ackOp : byte
   SKIPTARGET = 0xFF // jump to target
 };
 
+enum   CALLBACK_STATE : byte {
+  AFTER_WRITE,  // Start callback sequence after something was written to the decoder  
+  WAITING_100,        // Waiting for 100mS of stable power 
+  WAITING_30,         // waiting to 30ms of power off gap. 
+  READY,              // Ready to complete callback  
+  }; 
+
+
 // Allocations with memory implications..!
 // Base system takes approx 900 bytes + 8 per loco. Turnouts, Sensors etc are dynamically created
 #ifdef ARDUINO_AVR_UNO
@@ -141,12 +149,13 @@ private:
   static bool ackReceived;
   static bool ackManagerRejoin;
   static ACK_CALLBACK ackManagerCallback;
+  static CALLBACK_STATE callbackState;
   static void ackManagerSetup(int cv, byte bitNumOrbyteValue, ackOp const program[], ACK_CALLBACK callback);
   static void ackManagerSetup(int wordval, ackOp const program[], ACK_CALLBACK callback);
   static void ackManagerLoop();
   static bool checkResets( uint8_t numResets);
   static const int PROG_REPEATS = 8; // repeats of programming commands (some decoders need at least 8 to be reliable)
-
+  
   // NMRA codes #
   static const byte SET_SPEED = 0x3f;
   static const byte WRITE_BYTE_MAIN = 0xEC;

--- a/DCCWaveform.h
+++ b/DCCWaveform.h
@@ -161,8 +161,11 @@ class DCCWaveform {
     unsigned int ackPulseDuration;  // micros
     unsigned long ackPulseStart; // micros
 
-    unsigned int minAckPulseDuration = 2000; // micros
+    unsigned int minAckPulseDuration = 4000; // micros
     unsigned int maxAckPulseDuration = 8500; // micros
-           
+
+    volatile static uint8_t numAckGaps;
+    volatile static uint8_t numAckSamples;
+    static uint8_t trailingEdgeCounter;
 };
 #endif

--- a/version.h
+++ b/version.h
@@ -3,10 +3,12 @@
 
 #include "StringFormatter.h"
 
-#define VERSION "3.0.13"
+#define VERSION "3.0.14"
+// 3.0.14 gap in ack tolerant fix,  prog track power management over join fix. 
 // 3.0.13 Functions>127 fix
 // 3.0.12 Fix HOSTNAME function for STA mode for WiFi
 // 3.0.11 ?
+// 3.0.11 28 speedstep support
 // 3.0.10 Teensy Support
 // 3.0.9 rearranges serial newlines for the benefit of JMRI.
 // 3.0.8 Includes <* *> wraps around DIAGs for the benefit of JMRI.


### PR DESCRIPTION
Moved more setup out of the BASELINE loop so its not checked every time while waiting for reset counter.
Added REJOIN diag..

If you have a loco moving on prog and you do <R>, the loco will stop, ack its id, and then move off again as it gets the throttle reminder! 