### PR TITLE
Update DCC.cpp

### DIFF
--- a/DCC.cpp
+++ b/DCC.cpp
@@ -904,6 +904,10 @@ void DCC::callback(int value) {
 
     switch (callbackState) {    
        case AFTER_WRITE:  // first attempt to callback after a write operation
+	    if (!ackManagerRejoin && !DCCWaveform::progTrack.autoPowerOff) {
+               callbackState=READY;
+               break;
+            }                              // lines 906-910 added. avoid wait after write. use 1 PROG
             callbackStart=millis();
             callbackState=WAITING_100;
             if (Diag::ACK) DIAG(F("Stable 100mS"));


### PR DESCRIPTION
lines 907-910 added. avoid wait after write. use 1 PROG
This was the code Harald provided.  https://discord.com/channels/@me/743273217069809666/844623437808795658

Using <1 PROG> prior to reading full sheets in JMRI.  It can make a significant difference when there are large numbers of indexed CVs.

Chris noted:
> The delay will exist if you issue any writing command and (prog power is off   OR prog is joined) 
> 
> The ack manager restores the power state and join state after any prog command...
> During the command the power must be on and not joined..  so if the prog power is already on and not joined, it doesn't have to mess with anything