### PR TITLE
SH1106 OLED Display Offset Fix

### DIFF
--- a/SSD1306Ascii.cpp
+++ b/SSD1306Ascii.cpp
@@ -74,8 +74,8 @@ void SSD1306AsciiWire::setCursor(uint8_t col, uint8_t row) {
     m_col = col + m_colOffset;
     I2CManager.write(m_i2cAddr, 4,
       0x00,    // Set to command mode
-      SSD1306_SETLOWCOLUMN | (col & 0XF), 
-      SSD1306_SETHIGHCOLUMN | (col >> 4),
+      SSD1306_SETLOWCOLUMN | (m_col & 0XF), 
+      SSD1306_SETHIGHCOLUMN | (m_col >> 4),
       SSD1306_SETSTARTPAGE | m_row);
   }
 }

--- a/SSD1306init.h
+++ b/SSD1306init.h
@@ -182,6 +182,7 @@ static const uint8_t MEM_TYPE SH1106_128x64init[] = {
   0x00,                                  // Set to command mode
   SSD1306_DISPLAYOFF,
   SSD1306_SETSTARTPAGE | 0X0,            // set page address
+  SSD1306_SETSTARTLINE | 0x0,            // set start line
   SSD1306_SETCONTRAST, 0x80,             // 128
   SSD1306_SEGREMAP | 0X1,                // set segment remap
   SSD1306_NORMALDISPLAY,                 // normal / reverse


### PR DESCRIPTION
Correct display offset for SH1106.  The SH1106 supports 132 columns but most displays use 128 column OLED, connected to the middle columns 2-129.