### PR TITLE
Various HAL enhancements.

### DIFF
--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -802,7 +802,7 @@ bool DCCEXParser::parseD(Print *stream, int16_t params, int16_t p[])
         return true;
 
     case HASH_KEYWORD_SERVO:
-        IODevice::writeAnalogue(p[1], p[2], 0);
+        IODevice::writeAnalogue(p[1], p[2], params>3 ? p[3] : 0);
         break;
 
     default: // invalid/unknown

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -56,6 +56,7 @@ const int16_t HASH_KEYWORD_LCN = 15137;
 const int16_t HASH_KEYWORD_RESET = 26133;
 const int16_t HASH_KEYWORD_SPEED28 = -17064;
 const int16_t HASH_KEYWORD_SPEED128 = 25816;
+const int16_t HASH_KEYWORD_SERVO = 27709;
 
 int16_t DCCEXParser::stashP[MAX_COMMAND_PARAMS];
 bool DCCEXParser::stashBusy;
@@ -799,6 +800,10 @@ bool DCCEXParser::parseD(Print *stream, int16_t params, int16_t p[])
         DCC::setGlobalSpeedsteps(128);
 	StringFormatter::send(stream, F("128 Speedsteps"));
         return true;
+
+    case HASH_KEYWORD_SERVO:
+        IODevice::writeAnalogue(p[1], p[2], 0);
+        break;
 
     default: // invalid/unknown
         break;

--- a/IODevice.cpp
+++ b/IODevice.cpp
@@ -271,9 +271,6 @@ void IODevice::DumpAll() {
   DIAG(F("NO HAL CONFIGURED!"));
 }
 bool IODevice::exists(VPIN vpin) { return (vpin > 2 && vpin < 49); }
-void IODevice::remove(VPIN vpin) {
-  (void)vpin;  // Avoid compiler warnings
-}
 void IODevice::setGPIOInterruptPin(int16_t pinNumber) {
   (void) pinNumber; // Avoid compiler warning
 }

--- a/IODevice.h
+++ b/IODevice.h
@@ -136,9 +136,6 @@ public:
   // exists checks whether there is a device owning the specified vpin
   static bool exists(VPIN vpin);
 
-  // remove deletes the device associated with the vpin, if it is deletable
-  static void remove(VPIN vpin);
-
   // Enable shared interrupt on specified pin for GPIO extender modules.  The extender module
   // should pull down this pin when requesting a scan.  The pin may be shared by multiple modules.
   // Without the shared interrupt, input states are scanned periodically to detect changes on 
@@ -207,9 +204,6 @@ protected:
   // Destructor
   virtual ~IODevice() {};
   
-  // isDeletable returns true if object is deletable (i.e. is not a base device driver).
-  virtual bool _isDeletable();
-
   // Common object fields.
   VPIN _firstVpin;
   int _nPins;

--- a/IO_DCCAccessory.cpp
+++ b/IO_DCCAccessory.cpp
@@ -39,7 +39,12 @@ DCCAccessoryDecoder::DCCAccessoryDecoder(VPIN vpin, int nPins, int DCCAddress, i
    _firstVpin = vpin;
   _nPins = nPins;
   _packedAddress = (DCCAddress << 2) + DCCSubaddress;
+}
+
+void DCCAccessoryDecoder::_begin() {
   int endAddress = _packedAddress + _nPins - 1;
+  int DCCAddress = _packedAddress >> 2;
+  int DCCSubaddress = _packedAddress & 3;
   DIAG(F("DCC Accessory Decoder configured Vpins:%d-%d Linear Address:%d-%d (%d/%d-%d/%d)"), _firstVpin, _firstVpin+_nPins-1,
       _packedAddress, _packedAddress+_nPins-1,
      DCCAddress, DCCSubaddress, endAddress >> 2, endAddress % 4);

--- a/IO_ExampleSerial.h
+++ b/IO_ExampleSerial.h
@@ -17,6 +17,18 @@
  *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*
+ * To declare a device instance, 
+ *    IO_ExampleSerial myDevice(1000, 10, Serial3, 9600);
+ * or to create programmatically,
+ *    IO_ExampleSerial::create(1000, 10, Serial3, 9600);
+ * 
+ * (uses VPINs 1000-1009, talke on Serial 3 at 9600 baud.)
+ * 
+ * See IO_ExampleSerial.cpp for the protocol used over the serial line.
+ * 
+ */
+
 #ifndef IO_EXAMPLESERIAL_H
 #define IO_EXAMPLESERIAL_H
 
@@ -27,6 +39,7 @@ public:
   IO_ExampleSerial(VPIN firstVpin, int nPins, HardwareSerial *serial, unsigned long baud);
   static void create(VPIN firstVpin, int nPins, HardwareSerial *serial, unsigned long baud);  
 
+protected:
   void _begin() override;
   void _loop(unsigned long currentMicros) override;
   void _write(VPIN vpin, int value) override;
@@ -35,9 +48,11 @@ public:
 
 private:
   HardwareSerial *_serial;
-  uint8_t inputState = 0;
-  int inputIndex = 0;
-  int inputValue = 0;
+  uint8_t _inputState = 0;
+  int _inputIndex = 0;
+  int _inputValue = 0;
+  uint16_t *_pinValues; // Pointer to block of memory containing pin values
+  unsigned long _baud;
 };
 
 #endif // IO_EXAMPLESERIAL_H

--- a/IO_HCSR04.h
+++ b/IO_HCSR04.h
@@ -1,0 +1,177 @@
+/*
+ *  © 2021, Neil McKechnie. All rights reserved.
+ *  
+ *  This file is part of DCC++EX API
+ *
+ *  This is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  It is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* 
+ * The HC-SR04 module has an ultrasonic transmitter (40kHz) and a receiver.
+ * It is operated through two signal pins.  When the transmit pin is set to 1 for 
+ * 10us, on the falling edge the transmitter sends a short transmission of 
+ * 8 pulses (like a sonar 'ping').  This is reflected off objects and received
+ * by the receiver.  A pulse is sent on the receive pin whose length is equal
+ * to the delay between the transmission of the pulse and the detection of
+ * its echo.  The distance of the reflecting object is calculated by halving
+ * the time (to allow for the out and back distance), then multiplying by the
+ * speed of sound (assumed to be constant).
+ * 
+ * This driver polls the HC-SR04 by sending the trigger pulse and then measuring
+ * the length of the received pulse.  If the calculated distance is less than the
+ * threshold, the output changes to 1.  If it is greater than the threshold plus
+ * a hysteresis margin, the output changes to 0.
+ * 
+ * The measurement would be more reliable if interrupts were disabled while the
+ * pulse is being timed.  However, this would affect other functions in the CS
+ * so the measurement is being performed with interrupts enabled.  Also, we could
+ * use an interrupt pin in the Arduino for the timing, but the same consideration 
+ * applies.
+ * 
+ * Note: The timing accuracy required by this means that the pins have to be 
+ * direct Arduino pins; GPIO pins on an IO Extender cannot provide the required
+ * accuracy.
+ */
+
+#ifndef IO_HCSR04_H
+#define IO_HCSR04_H
+
+#include "IODevice.h"
+
+class HCSR04 : public IODevice {
+
+private:
+  // pins must be arduino GPIO pins, not extender pins or HAL pins.
+  int _transmitPin = -1;
+  int _receivePin = -1;
+  // Threshold for setting active state in cm.
+  uint16_t _threshold;  // cm
+  // Active=1/inactive=0 state 
+  uint8_t _value = 0;
+  // Time of last loop execution
+  unsigned long _lastExecutionTime;
+  // Hysteresis for deactivating state, in cm
+  const uint16_t hysteresis = 3; // cm
+  const uint16_t factor = 58; // ms/cm
+
+public:
+  // Constructor perfroms static initialisation of the device object
+  HCSR04 (VPIN vpin, int transmitPin, int receivePin, uint16_t threshold) {
+    _firstVpin = vpin;
+    _nPins = 1;
+    _transmitPin = transmitPin;
+    _receivePin = receivePin;
+    _threshold = threshold;
+    addDevice(this);
+  }
+
+  // Static create function provides alternative way to create object
+  static void create(VPIN vpin, int transmitPin, int receivePin, uint16_t threshold) {
+    new HCSR04(vpin, transmitPin, receivePin, threshold);
+  }
+
+protected:
+  // _begin function called to perform dynamic initialisation of the device
+  void _begin() override {
+    pinMode(_transmitPin, OUTPUT);
+    pinMode(_receivePin, INPUT);
+    ArduinoPins::fastWriteDigital(_transmitPin, 0);
+    _lastExecutionTime = micros();
+    DIAG(F("HCSR04 configured Vpin:%d TX:%d RX:%d"), _firstVpin, _transmitPin, _receivePin);
+  }
+
+  // TODO: Move this to the _loop function to execute periodically, and just return _value here.
+  int _read(VPIN vpin) override {
+    (void)vpin;  // avoid compiler warning
+    return _value;
+  }
+
+  // loop function - read HC-SR04 once every 50 milliseconds.
+  void _loop(unsigned long currentMicros) override {
+    if (currentMicros - _lastExecutionTime > 50000) {
+      _lastExecutionTime = currentMicros;
+
+      read_HCSR04device();
+    }
+  }
+
+private:
+  // This polls the HC-SR04 device by sending a pulse and measuring the duration of
+  //  the pulse observed on the receive pin.  In order to be kind to the rest of the CS
+  //  software, no interrupts are used and interrupts are not disabled.  The pulse duration
+  //  is measured in a loop, using the micros() function.  Therefore, interrupts from other
+  //  sources may affect the result.  To mitigate this, the time between successive loops is
+  //  tested and if it is excessive the current measurement is discarded (previous value is returned
+  //  instead).  Also, hysteresis is applied on reset: the output is set to 1 when the 
+  //  measured distance is less than the threshold, and is set to 0 if the measured distance is
+  //  greater than the threshold plus 3cm.
+  //
+  void read_HCSR04device() {
+    // uint16 enough to time up to 65ms
+    uint16_t startTime, waitTime, currentTime, lastTime, maxTime;  
+
+    // If receive pin is still set on from previous call, abort the read.
+    if (ArduinoPins::fastReadDigital(_receivePin)) return;
+
+    // Send 10us pulse to trigger transmitter
+    ArduinoPins::fastWriteDigital(_transmitPin, 1);
+    delayMicroseconds(10);
+    ArduinoPins::fastWriteDigital(_transmitPin, 0);
+
+    // Wait for receive pin to be set
+    startTime = currentTime = micros();
+    maxTime = factor * _threshold * 2;
+    while (!ArduinoPins::fastReadDigital(_receivePin)) {
+      lastTime = currentTime;
+      currentTime = micros();
+      waitTime = currentTime - startTime;
+      if (waitTime > maxTime) {
+        // Timeout waiting for pulse start, abort the read
+        return;
+      }
+    }
+    // Check if loop was unreasonably delayed by interrupts.
+    // If so, abort the read as the measurement might
+    // be reduced by the delay.
+    if (currentTime - lastTime > 25) return;
+
+    // Wait for receive pin to reset, and measure length of pulse
+    startTime = currentTime = micros();
+    maxTime = factor * (_threshold + hysteresis);
+    while (ArduinoPins::fastReadDigital(_receivePin)) {
+      lastTime = currentTime;
+      currentTime = micros();
+      waitTime = currentTime - startTime;
+      // If pulse is too long then set return value to zero,
+      //  and finish without waiting for end of pulse.
+      if (waitTime > maxTime) {
+        // Check if loop was unreasonably delayed by interrupts.
+        // If so, abort calculation as the measurement might
+        // have been increased by the delay.
+        if (currentTime - lastTime > 25) return;
+        // Pulse length longer than maxTime, reset value.
+        _value = 0;
+        return;
+      }
+    } 
+    // Check if pulse length is below threshold, if so set value.
+    //DIAG(F("HCSR04: Pulse Len=%l Distance=%d"), waitTime, distance);
+    uint16_t distance = waitTime / factor; // in centimetres
+    if (distance < _threshold) 
+      _value = 1;
+  }
+
+};
+
+#endif //IO_HCSR04_H

--- a/IO_HCSR04.h
+++ b/IO_HCSR04.h
@@ -55,30 +55,32 @@ private:
   // pins must be arduino GPIO pins, not extender pins or HAL pins.
   int _transmitPin = -1;
   int _receivePin = -1;
-  // Threshold for setting active state in cm.
-  uint16_t _threshold;  // cm
+  // Thresholds for setting active state in cm.
+  uint8_t _onThreshold;  // cm
+  uint8_t _offThreshold; // cm
   // Active=1/inactive=0 state 
   uint8_t _value = 0;
   // Time of last loop execution
   unsigned long _lastExecutionTime;
-  // Hysteresis for deactivating state, in cm
-  const uint16_t hysteresis = 3; // cm
+  // Factor for calculating the distance (cm) from echo time (ms).
+  //  Based on a speed of sound of 345 metres/second.
   const uint16_t factor = 58; // ms/cm
 
 public:
   // Constructor perfroms static initialisation of the device object
-  HCSR04 (VPIN vpin, int transmitPin, int receivePin, uint16_t threshold) {
+  HCSR04 (VPIN vpin, int transmitPin, int receivePin, uint16_t onThreshold, uint16_t offThreshold) {
     _firstVpin = vpin;
     _nPins = 1;
     _transmitPin = transmitPin;
     _receivePin = receivePin;
-    _threshold = threshold;
+    _onThreshold = onThreshold;
+    _offThreshold = offThreshold;
     addDevice(this);
   }
 
   // Static create function provides alternative way to create object
-  static void create(VPIN vpin, int transmitPin, int receivePin, uint16_t threshold) {
-    new HCSR04(vpin, transmitPin, receivePin, threshold);
+  static void create(VPIN vpin, int transmitPin, int receivePin, uint16_t onThreshold, uint16_t offThreshold) {
+    new HCSR04(vpin, transmitPin, receivePin, onThreshold, offThreshold);
   }
 
 protected:
@@ -88,7 +90,8 @@ protected:
     pinMode(_receivePin, INPUT);
     ArduinoPins::fastWriteDigital(_transmitPin, 0);
     _lastExecutionTime = micros();
-    DIAG(F("HCSR04 configured on VPIN:%d TXpin:%d RXpin:%d threshold:%dcm"), _firstVpin, _transmitPin, _receivePin, _threshold);
+    DIAG(F("HCSR04 configured on VPIN:%d TXpin:%d RXpin:%d On:%dcm Off:%dcm"),
+      _firstVpin, _transmitPin, _receivePin, _onThreshold, _offThreshold);
   }
 
   // _read function - just return _value (calculated in _loop).
@@ -102,7 +105,7 @@ protected:
     if (currentMicros - _lastExecutionTime > 50000) {
       _lastExecutionTime = currentMicros;
 
-      read_HCSR04device();
+      _value = read_HCSR04device();
     }
   }
 
@@ -111,18 +114,19 @@ private:
   //  the pulse observed on the receive pin.  In order to be kind to the rest of the CS
   //  software, no interrupts are used and interrupts are not disabled.  The pulse duration
   //  is measured in a loop, using the micros() function.  Therefore, interrupts from other
-  //  sources may affect the result.  To mitigate this, the time between successive loops is
-  //  tested and if it is excessive the current measurement is aborted (previous value is
-  //  retained).  Also, hysteresis is applied on reset: the output is set to 1 when the 
-  //  measured distance is less than the threshold, and is set to 0 if the measured distance is
-  //  greater than the threshold plus 3cm.
+  //  sources may affect the result.  However, interrupts response code in CS typically takes
+  //  much less than the 58us frequency for the DCC interrupt, and 58us corresponds to only 1cm
+  //  in the HC-SR04.
+  //  To reduce chatter on the output, hysteresis is applied on reset: the output is set to 1 when the 
+  //  measured distance is less than the onThreshold, and is set to 0 if the measured distance is
+  //  greater than the offThreshold.
   //
-  void read_HCSR04device() {
+  uint8_t read_HCSR04device() {
     // uint16 enough to time up to 65ms
-    uint16_t startTime, waitTime, currentTime, lastTime, maxTime;  
+    uint16_t startTime, waitTime, currentTime, maxTime;  
 
     // If receive pin is still set on from previous call, abort the read.
-    if (ArduinoPins::fastReadDigital(_receivePin)) return;
+    if (ArduinoPins::fastReadDigital(_receivePin)) return _value;
 
     // Send 10us pulse to trigger transmitter
     ArduinoPins::fastWriteDigital(_transmitPin, 1);
@@ -131,45 +135,37 @@ private:
 
     // Wait for receive pin to be set
     startTime = currentTime = micros();
-    maxTime = factor * _threshold * 2;
+    maxTime = factor * _offThreshold * 2;
     while (!ArduinoPins::fastReadDigital(_receivePin)) {
-      lastTime = currentTime;
+      // lastTime = currentTime;
       currentTime = micros();
       waitTime = currentTime - startTime;
       if (waitTime > maxTime) {
         // Timeout waiting for pulse start, abort the read
-        return;
+        return _value;
       }
     }
-    // Check if loop was unreasonably delayed by interrupts.
-    // If so, abort the read as the measurement might
-    // be reduced by the delay.
-    if (currentTime - lastTime >= factor) return;
 
     // Wait for receive pin to reset, and measure length of pulse
     startTime = currentTime = micros();
-    maxTime = factor * (_threshold + hysteresis);
+    maxTime = factor * _offThreshold;
     while (ArduinoPins::fastReadDigital(_receivePin)) {
-      lastTime = currentTime;
       currentTime = micros();
       waitTime = currentTime - startTime;
       // If pulse is too long then set return value to zero,
       //  and finish without waiting for end of pulse.
       if (waitTime > maxTime) {
-        // Check if loop was unreasonably delayed by interrupts.
-        // If so, abort calculation as the measurement might
-        // have been increased by the delay.
-        if (currentTime - lastTime >= factor) return;
         // Pulse length longer than maxTime, reset value.
-        _value = 0;
-        return;
+        return 0;
       }
     } 
     // Check if pulse length is below threshold, if so set value.
     //DIAG(F("HCSR04: Pulse Len=%l Distance=%d"), waitTime, distance);
     uint16_t distance = waitTime / factor; // in centimetres
-    if (distance < _threshold) 
-      _value = 1;
+    if (distance < _onThreshold) 
+      return 1;
+
+    return _value;
   }
 
 };

--- a/IO_MCP23008.h
+++ b/IO_MCP23008.h
@@ -28,7 +28,6 @@ public:
     new MCP23008(firstVpin, nPins, I2CAddress, interruptPin);
   }
 
-private:
   // Constructor
   MCP23008(VPIN firstVpin, uint8_t nPins, uint8_t I2CAddress, int interruptPin=-1)
     : GPIOBase<uint8_t>((FSH *)F("MCP23008"), firstVpin, min(nPins, 8), I2CAddress, interruptPin) {
@@ -38,6 +37,7 @@ private:
     outputBuffer[0] = REG_GPIO;
   }
   
+private:
   void _writeGpioPort() override {
     I2CManager.write(_I2CAddress, 2, REG_GPIO, _portOutputState);
   }

--- a/IO_MCP23017.h
+++ b/IO_MCP23017.h
@@ -34,7 +34,6 @@ public:
     new MCP23017(vpin, min(nPins,16), I2CAddress, interruptPin);
   }
   
-private:
   // Constructor
   MCP23017(VPIN vpin, int nPins, uint8_t I2CAddress, int interruptPin=-1) 
     : GPIOBase<uint16_t>((FSH *)F("MCP23017"), vpin, nPins, I2CAddress, interruptPin) 
@@ -42,9 +41,9 @@ private:
     requestBlock.setRequestParams(_I2CAddress, inputBuffer, sizeof(inputBuffer),
       outputBuffer, sizeof(outputBuffer));
     outputBuffer[0] = REG_GPIOA;
-    _setupDevice();
   }
 
+private:
   void _writeGpioPort() override {
     I2CManager.write(_I2CAddress, 3, REG_GPIOA, _portOutputState, _portOutputState>>8);
   }

--- a/IO_PCA9685.cpp
+++ b/IO_PCA9685.cpp
@@ -82,6 +82,10 @@ PCA9685::PCA9685(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
 
   // Initialise structure used for setting pulse rate
   requestBlock.setWriteParams(_I2CAddress, outputBuffer, sizeof(outputBuffer));
+}
+
+// Device-specific initialisation
+void PCA9685::_begin() {
   I2CManager.begin();
   I2CManager.setClock(1000000); // Nominally able to run up to 1MHz on I2C
           // In reality, other devices including the Arduino will limit 
@@ -98,10 +102,6 @@ PCA9685::PCA9685(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
     // the PWM oscillator to get running.  However, we don't do any specific wait, as there's 
     // plenty of other stuff to do before we will send a command.
   }
-}
-
-// Device-specific initialisation
-void PCA9685::_begin() {
 }
 
 // Device-specific write function, invoked from IODevice::write().

--- a/IO_PCA9685.cpp
+++ b/IO_PCA9685.cpp
@@ -166,7 +166,7 @@ void PCA9685::_writeAnalogue(VPIN vpin, int value, int profile) {
                 profile==Bounce ? sizeof(_bounceProfile)-1 : 
                 1;
   s->stepNumber = 0;
-  s->toPosition = min(value, 4095);
+  s->toPosition = value;
   s->fromPosition = s->currentPosition;
 }
 

--- a/IO_PCF8574.h
+++ b/IO_PCF8574.h
@@ -28,13 +28,13 @@ public:
     new PCF8574(firstVpin, nPins, I2CAddress, interruptPin);
   }
 
-private:
   PCF8574(VPIN firstVpin, uint8_t nPins, uint8_t I2CAddress, int interruptPin=-1)
     : GPIOBase<uint8_t>((FSH *)F("PCF8574"), firstVpin, min(nPins, 8), I2CAddress, interruptPin) 
   {
     requestBlock.setReadParams(_I2CAddress, inputBuffer, 1);
   }
   
+private:
   // The pin state is '1' if the pin is an input or if it is an output set to 1.  Zero otherwise. 
   void _writeGpioPort() override {
     I2CManager.write(_I2CAddress, 1, _portOutputState | ~_portMode);
@@ -73,7 +73,10 @@ private:
       _portInputState = 0xff;
   }
 
-  void _setupDevice() override { }
+  // Set up device ports
+  void _setupDevice() override { 
+    _writePortModes();
+  }
  
   uint8_t inputBuffer[1];
 };

--- a/Sensors.cpp
+++ b/Sensors.cpp
@@ -91,7 +91,7 @@ void Sensor::checkAll(Print *stream){
 #ifdef USE_NOTIFY
   // Register the event handler ONCE!
   if (!inputChangeCallbackRegistered)
-    nextInputChangeCallback = IODevice::registerInputChangeNotification(inputChangeCallback);
+    IONotifyCallback::add(inputChangeCallback);
   inputChangeCallbackRegistered = true;
 #endif
 
@@ -192,8 +192,6 @@ void Sensor::inputChangeCallback(VPIN vpin, int state) {
   if (tt != NULL) { // Sensor found
     tt->inputState = (state != 0); 
   }
-  // Call next registered callback function
-  if (nextInputChangeCallback) nextInputChangeCallback(vpin, state);
 }
 #endif
 
@@ -345,6 +343,5 @@ unsigned long Sensor::lastReadCycle=0;
 Sensor *Sensor::firstPollSensor = NULL;
 Sensor *Sensor::lastSensor = NULL;
 bool Sensor::pollSignalPhase = false;
-IONotifyStateChangeCallback *Sensor::nextInputChangeCallback = 0;
 bool Sensor::inputChangeCallbackRegistered = false;
 #endif

--- a/Sensors.h
+++ b/Sensors.h
@@ -92,7 +92,6 @@ public:
 #ifdef USE_NOTIFY
   static bool pollSignalPhase;
   static void inputChangeCallback(VPIN vpin, int state);
-  static IONotifyStateChangeCallback *nextInputChangeCallback;
   static bool inputChangeCallbackRegistered;
 #endif
   


### PR DESCRIPTION
Add new `<D SERVO vpin position profile>` command (profile is optional).
Allow HAL device drivers to be statically created by declaration, as an alternative to calling the create() method.
New HAL HC-SR04 driver.
Add on-change notification for GPIOBase class (and implicitly to its subclasses MCP23017, MCP23008 and PCF8574).
Some restructuring of Turnout class to prevent RMFT compile error in IO_NO_HAL mode (basic HAL).