### PR TITLE
Clarify config.h entry for an OLED with a SH1106

### DIFF
--- a/config.example.h
+++ b/config.example.h
@@ -125,7 +125,7 @@ The configuration file for DCC-EX Command Station
 
 //OR define OLED_DRIVER width,height in pixels (address auto detected)
 // 128x32 or 128x64 I2C SSD1306-based devices are supported.
-// Also 132x64 I2C SH1106 devices
+// Use 132,64 for a SH1106-based I2C device with a 128x64 display.
 // #define OLED_DRIVER 128,32
 
 // Define scroll mode as 0, 1 or 2


### PR DESCRIPTION
See:
79763a3 ("SH1106 OLED Display Offset Fix (#169)", 2021-06-10)
97f3450 ("Simplify OLED driver initialisation.", 2021-11-24)

---

Wasn't obvious to me what to set OLED_DRIVER to when I had an OLED display described as 128x64. Here's my attempt to make it clearer.
