### PR TITLE
Make EngineDriver work

### DIFF
--- a/WiThrottle.cpp
+++ b/WiThrottle.cpp
@@ -115,6 +115,8 @@ void WiThrottle::parse(RingStream * stream, byte * cmdx) {
   if (Diag::WITHROTTLE) DIAG(F("%l WiThrottle(%d)<-[%e]"),millis(),clientid,cmd);
 
   if (initSent) {
+    if (cmd[0] == 'N' && cmd[1] == 'E' && cmd[2] == 'n') // EngineDriver do not support heartBeat !
+      heartBeatEnable = false;
     // Send turnout list if changed since last sent (will replace list on client)
     if (turnoutListHash != Turnout::turnoutlistHash) {
       StringFormatter::send(stream,F("PTL"));
@@ -139,6 +141,7 @@ void WiThrottle::parse(RingStream * stream, byte * cmdx) {
       RMFT2::emitWithrottleRouteList(stream);
 #endif
       // allow heartbeat to slow down once all metadata sent     
+      if (heartBeatEnable)
       StringFormatter::send(stream,F("*%d\n"),HEARTBEAT_SECONDS);
     }
   }
@@ -209,7 +212,9 @@ void WiThrottle::parse(RingStream * stream, byte * cmdx) {
 	RMFT2::emitWithrottleRoster(stream);
 #endif        
 	// set heartbeat to 1 second because we need to sync the metadata
+        if (heartBeatEnable) {
 	StringFormatter::send(stream,F("*1\n"));
+        }
 	initSent = true;
       }
       break;           


### PR DESCRIPTION
The program EngineDriver for Android, using the same protocol as WiThrottle, do not handle heartBeat. So in this case, remove the timings sent to the throttle ("*1" and "*10").