### PR TITLE
Add text activities

### DIFF
--- a/EXRAILMacros.h
+++ b/EXRAILMacros.h
@@ -209,7 +209,7 @@ const  FLASH  int16_t RMFT2::SignalDefinitions[] = {
 #define LATCH(sensor_id) OPCODE_LATCH,V(sensor_id),
 #define LCD(id,msg) PRINT(msg)
 #define LCN(msg) PRINT(msg)
-#define MOVETT(id,steps,activity) OPCODE_SERVO,V(id),OPCODE_PAD,V(steps),OPCODE_PAD,V(activity),OPCODE_PAD,V(0),
+#define MOVETT(id,steps,activity) OPCODE_SERVO,V(id),OPCODE_PAD,V(steps),OPCODE_PAD,V(TurntableEX::activity),OPCODE_PAD,V(0),
 #define ONACTIVATE(addr,subaddr) OPCODE_ONACTIVATE,V(addr<<2|subaddr),
 #define ONACTIVATEL(linear) OPCODE_ONACTIVATE,V(linear+3),
 #define ONCLOSE(turnout_id) OPCODE_ONCLOSE,V(turnout_id),

--- a/IODevice.h
+++ b/IODevice.h
@@ -363,6 +363,40 @@ private:
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+ * IODevice subclass for Turntable-EX.
+ */
+ 
+class TurntableEX : public IODevice {
+public:
+  static void create(VPIN firstVpin, int nPins, uint8_t I2CAddress);
+  // Constructor
+  TurntableEX(VPIN firstVpin, int nPins, uint8_t I2CAddress);
+  enum ActivityNumber : uint8_t {
+    Turn = 0,             // Rotate turntable, maintain phase
+    Turn_PInvert = 1,     // Rotate turntable, invert phase
+    Home = 2,             // Initiate homing
+    Calibrate = 3,        // Initiate calibration sequence
+    LED_On = 4,           // Turn LED on
+    LED_Slow = 5,         // Set LED to a slow blink
+    LED_Fast = 6,         // Set LED to a fast blink
+    LED_Off = 7,          // Turn LED off
+    Acc_On = 8,           // Turn accessory pin on
+    Acc_Off = 9,          // Turn accessory pin off
+  };
+
+private:
+  // Device-specific write function.
+  void _begin() override;
+  void _loop(unsigned long currentMicros) override;
+  int _read(VPIN vpin) override;
+  void _writeAnalogue(VPIN vpin, int value, uint8_t activity, uint16_t duration) override;
+  void _display() override;
+  uint8_t _I2CAddress;
+  uint8_t _stepperStatus;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "IO_MCP23008.h"
 #include "IO_MCP23017.h"

--- a/IO_TurntableEX.h
+++ b/IO_TurntableEX.h
@@ -55,7 +55,7 @@ public:
       LED_Fast = 6,         // Set LED to a fast blink - new feature not implemented yet
       LED_Off = 7,          // Turn LED off - new feature not implemented yet
       Acc_On = 8,           // Turn accessory pin on - new feature not implemented yet
-      Acc_On = 9,           // Turn accessory pin off - new feature not implemented yet
+      Acc_Off = 9,           // Turn accessory pin off - new feature not implemented yet
     };
   }
 

--- a/IO_TurntableEX.h
+++ b/IO_TurntableEX.h
@@ -18,19 +18,14 @@
 */
 
 /*
-* The IO_TurntableEX device driver is used to control a turntable via an Arduino Nano with a stepper motor over I2C.
+* The IO_TurntableEX device driver is used to control a turntable via an Arduino with a stepper motor over I2C.
 *
-* The Nano code lives in a separate repo (https://github.com/DCC-EX/Turntable-EX) and contains the stepper motor logic.
+* The Turntable-EX code lives in a separate repo (https://github.com/DCC-EX/Turntable-EX) and contains the stepper motor logic.
 *
-* This device driver sends an integer/byte to the Nano to indicate the position to move to using an EX-RAIL SERVO
-* command, with the position in place of the PWM value. The profile value is used to flag phase/polarity switching
-* or other activities as defined in Turntable-EX.
-*
-* For example, a ROUTE used for position one:
-*
-* ROUTE(600, "Layout connection")
-*   SERVO(600, 1, Instant)
-*   DONE
+* This device driver sends a step position to Turntable-EX to indicate the step position to move to using either of these commands:
+* <D TT vpin steps activity> in the serial console
+* MOVETT(vpin, steps, activity) in EX-RAIL
+* Refer to the documentation for further information including the valid activities.
 */
 
 #ifndef IO_TurntableEX_h
@@ -40,98 +35,87 @@
 #include "I2CManager.h"
 #include "DIAG.h"
 
-class TurntableEX : public IODevice {
+void TurntableEX::create(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
+  new TurntableEX(firstVpin, nPins, I2CAddress);
+}
 
-public:
-  static void create(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
-    new TurntableEX(firstVpin, nPins, I2CAddress);
-    enum ActivityNumber : uint8_t {
-      Turn = 0,             // Rotate turntable, maintain phase
-      Turn_PInvert = 1,     // Rotate turntable, invert phase
-      Home = 2,             // Initiate homing
-      Calibrate = 3,        // Initiate calibration sequence - new feature not implemented yet
-      LED_On = 4,           // Turn LED on - new feature not implemented yet
-      LED_Slow = 5,         // Set LED to a slow blink - new feature not implemented yet
-      LED_Fast = 6,         // Set LED to a fast blink - new feature not implemented yet
-      LED_Off = 7,          // Turn LED off - new feature not implemented yet
-      Acc_On = 8,           // Turn accessory pin on - new feature not implemented yet
-      Acc_Off = 9,           // Turn accessory pin off - new feature not implemented yet
-    };
-  }
-
-  // Constructor
-  TurntableEX(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
-    _firstVpin = firstVpin;
-    _nPins = nPins;
-    _I2CAddress = I2CAddress;
-    addDevice(this);
-  }
-
-private:
-  uint8_t _I2CAddress;
-  uint8_t _stepperStatus;
+// Constructor
+TurntableEX::TurntableEX(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
+  _firstVpin = firstVpin;
+  _nPins = nPins;
+  _I2CAddress = I2CAddress;
+  addDevice(this);
+}
 
 // Initialisation of TurntableEX
-  void _begin() {
-    I2CManager.begin();
-    I2CManager.setClock(1000000);
-    if (I2CManager.exists(_I2CAddress)) {
+void TurntableEX::_begin() {
+  I2CManager.begin();
+  I2CManager.setClock(1000000);
+  if (I2CManager.exists(_I2CAddress)) {
 #ifdef DIAG_IO
-      _display();
+    _display();
 #endif
-    } else {
-      _deviceState = DEVSTATE_FAILED;
-    }
+  } else {
+    _deviceState = DEVSTATE_FAILED;
   }
+}
 
 // Processing loop to obtain status of stepper
 // 0 = finished moving and in correct position
 // 1 = still moving
-// 2 = finished moving, in incorrect position
-  void _loop(unsigned long currentMicros) {
-    uint8_t readBuffer[1];
-    I2CManager.read(_I2CAddress, readBuffer, 1);
-    _stepperStatus = readBuffer[0];
-    // DIAG(F("Turntable-EX returned status: %d"), _stepperStatus);
-    delayUntil(currentMicros + 500000);  // Wait 500ms before checking again, turntables turn slowly
-  }
+void TurntableEX::_loop(unsigned long currentMicros) {
+  uint8_t readBuffer[1];
+  I2CManager.read(_I2CAddress, readBuffer, 1);
+  _stepperStatus = readBuffer[0];
+  // DIAG(F("Turntable-EX returned status: %d"), _stepperStatus);
+  delayUntil(currentMicros + 500000);  // Wait 500ms before checking again, turntables turn slowly
+}
 
 // Read returns status as obtained in our loop.
 // Return false if our status value is invalid.
-  int _read(VPIN vpin) {
-    if (_deviceState == DEVSTATE_FAILED) return 0;
-    // DIAG(F("_read status: %d"), _stepperStatus);
-    if (_stepperStatus > 1) {
-      return false;
-    } else {
-      return _stepperStatus;
-    }
+int TurntableEX::_read(VPIN vpin) {
+  if (_deviceState == DEVSTATE_FAILED) return 0;
+  // DIAG(F("_read status: %d"), _stepperStatus);
+  if (_stepperStatus > 1) {
+    return false;
+  } else {
+    return _stepperStatus;
   }
+}
 
 // writeAnalogue to send the steps and activity to Turntable-EX.
 // Sends 3 bytes containing the MSB and LSB of the step count, and activity.
 // value contains the steps, bit shifted to MSB + LSB.
-// profile contains the activity.
-  void _writeAnalogue(VPIN vpin, int value, uint8_t profile, uint16_t duration) {
-    if (_deviceState == DEVSTATE_FAILED) return;
-    uint8_t stepsMSB = value >> 8;
-    uint8_t stepsLSB = value & 0xFF;
+// activity contains the activity flag as per this list:
+// 
+// Turn = 0,             // Rotate turntable, maintain phase
+// Turn_PInvert = 1,     // Rotate turntable, invert phase
+// Home = 2,             // Initiate homing
+// Calibrate = 3,        // Initiate calibration sequence
+// LED_On = 4,           // Turn LED on
+// LED_Slow = 5,         // Set LED to a slow blink
+// LED_Fast = 6,         // Set LED to a fast blink
+// LED_Off = 7,          // Turn LED off
+// Acc_On = 8,           // Turn accessory pin on
+// Acc_Off = 9           // Turn accessory pin off
+void TurntableEX::_writeAnalogue(VPIN vpin, int value, uint8_t activity, uint16_t duration) {
+  if (_deviceState == DEVSTATE_FAILED) return;
+  uint8_t stepsMSB = value >> 8;
+  uint8_t stepsLSB = value & 0xFF;
 #ifdef DIAG_IO
-    DIAG(F("TurntableEX WriteAnalogue Vpin:%d Value:%d Profile:%d Duration:%d"),
-      vpin, value, profile, duration);
-    DIAG(F("I2CManager write I2C Address:%d stepsMSB:%d stepsLSB:%d profile:%d"),
-      _I2CAddress, stepsMSB, stepsLSB, profile);
+  DIAG(F("TurntableEX WriteAnalogue Vpin:%d Value:%d Activity:%d Duration:%d"),
+    vpin, value, activity, duration);
+  DIAG(F("I2CManager write I2C Address:%d stepsMSB:%d stepsLSB:%d activity:%d"),
+    _I2CAddress, stepsMSB, stepsLSB, activity);
 #endif
-    _stepperStatus = 1;     // Tell the device driver Turntable-EX is busy
-    I2CManager.write(_I2CAddress, 3, stepsMSB, stepsLSB, profile);
-  }
+  _stepperStatus = 1;     // Tell the device driver Turntable-EX is busy
+  I2CManager.write(_I2CAddress, 3, stepsMSB, stepsLSB, activity);
+}
 
 // Display Turnetable-EX device driver info.
-  void _display() {
-    DIAG(F("TurntableEX I2C:x%x Configured on Vpins:%d-%d %S"), _I2CAddress, (int)_firstVpin, 
-      (int)_firstVpin+_nPins-1, (_deviceState==DEVSTATE_FAILED) ? F("OFFLINE") : F(""));
-  }
-
-};
+void TurntableEX::_display() {
+  DIAG(F("TurntableEX I2C:x%x Configured on Vpins:%d-%d %S"), _I2CAddress, (int)_firstVpin, 
+    (int)_firstVpin+_nPins-1, (_deviceState==DEVSTATE_FAILED) ? F("OFFLINE") : F(""));
+}
 
 #endif

--- a/IO_TurntableEX.h
+++ b/IO_TurntableEX.h
@@ -45,6 +45,18 @@ class TurntableEX : public IODevice {
 public:
   static void create(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
     new TurntableEX(firstVpin, nPins, I2CAddress);
+    enum ActivityNumber : uint8_t {
+      Turn = 0,             // Rotate turntable, maintain phase
+      Turn_PInvert = 1,     // Rotate turntable, invert phase
+      Home = 2,             // Initiate homing
+      Calibrate = 3,        // Initiate calibration sequence - new feature not implemented yet
+      LED_On = 4,           // Turn LED on - new feature not implemented yet
+      LED_Slow = 5,         // Set LED to a slow blink - new feature not implemented yet
+      LED_Fast = 6,         // Set LED to a fast blink - new feature not implemented yet
+      LED_Off = 7,          // Turn LED off - new feature not implemented yet
+      Acc_On = 8,           // Turn accessory pin on - new feature not implemented yet
+      Acc_On = 9,           // Turn accessory pin off - new feature not implemented yet
+    };
   }
 
   // Constructor


### PR DESCRIPTION
Updated IO_TurntableEX.h, IODevice.h, and EXRAILMacros.h to enable sending text commands to Turntable-EX via the MOVETT() command rather than the numbers to help make the desired activity easier to understand when reviewing myAutomation.h.