### PR TITLE
Adjust forget commands to respect the direction of engines

### DIFF
--- a/DCC.h
+++ b/DCC.h
@@ -102,6 +102,7 @@ public:
  static byte cv2(int cv);
  
 private:
+  static byte calculateSpeedByte(uint8_t tSpeed, bool tDirection);
   static byte loopStatus;
   static void setThrottle2(uint16_t cab, uint8_t speedCode);
   static void updateLocoReminder(int loco, byte speedCode);


### PR DESCRIPTION
Replaces #23, targeting the TrackManager branch instead of master, to get into the next major update, not a minor one. 

Currently forgetting an engine that is still on the track (for example on a siding) will cause it to get a "backwards e-stop", potentially changing it's direction.
With this PR, the CS should send the e-stop packets with the correct direction. 

- `DCC::forgetLoco` calls the setThrottle function twice - I'm not sure why, but assumed it's to ensure that the loco actually gets the packet, since it's not gonna get any reminders. `DCC::forgetAllLocos` doesn't send it twice. Should I adjust one of them?