### PR TITLE
Keep Ethernet singleton "alive" until connection is established.

### DIFF
--- a/EthernetInterface.h
+++ b/EthernetInterface.h
@@ -60,6 +60,9 @@ class EthernetInterface {
      bool connected;
      EthernetInterface();
      void loop2();
+
+     bool checkLink();
+
     EthernetServer * server;
     EthernetClient clients[MAX_SOCK_NUM];                // accept up to MAX_SOCK_NUM client connections at the same time; This depends on the chipset used on the Shield
     uint8_t buffer[MAX_ETH_BUFFER+1];                    // buffer used by TCP for the recv

--- a/EthernetInterface.h
+++ b/EthernetInterface.h
@@ -59,14 +59,15 @@ class EthernetInterface {
      static EthernetInterface * singleton;
      bool connected;
      EthernetInterface();
+     ~EthernetInterface();
      void loop2();
 
      bool checkLink();
 
-    EthernetServer * server;
+    EthernetServer * server = nullptr;
     EthernetClient clients[MAX_SOCK_NUM];                // accept up to MAX_SOCK_NUM client connections at the same time; This depends on the chipset used on the Shield
     uint8_t buffer[MAX_ETH_BUFFER+1];                    // buffer used by TCP for the recv
-    RingStream * outboundRing;
+    RingStream * outboundRing = nullptr;
   
 };
 


### PR DESCRIPTION
Instead of keeping a limited loop during Ethernet setup, I propose this change to keep checking the link status until it becomes stable and ethernet link is stable and ip is obtained. 

This makes life easier for debugging and testing, also if for some reason the link takes longer to becomes stable, the initialization process will not kill the ehternet singleton.