### PR TITLE
Allow throttles to request the current track power status.

### DIFF
--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -481,6 +481,10 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
         return;
         }
 
+    case '*': // Get current power status
+        CommandDistributor::broadcastPower();
+        return;
+
     case '!': // ESTOP ALL  <!>
         DCC::setThrottle(0,1,1); // this broadcasts speed 1(estop) and sets all reminders to speed 1.
         return;


### PR DESCRIPTION
Allow a throttle to request the current track power status.
The `<*>` command will run `CommandDistributor::broadcastPower();`.

@DCC-EX/developers Is the overhead of `CommandDistributor::broadcastPower();` worth breaking out the code a bit more so only the requester receives the result instead of a broadcast?