### PR TITLE
Extended `<s>` command

### DIFF
--- a/DCCEXParser.h
+++ b/DCCEXParser.h
@@ -47,6 +47,7 @@ struct DCCEXParser
     static bool parseT(Print * stream, int16_t params, int16_t p[]);
      static bool parseZ(Print * stream, int16_t params, int16_t p[]);
      static bool parseS(Print * stream,  int16_t params, int16_t p[]);
+     static void parseLowerS(Print *stream, int16_t params, int16_t p[]);
      static bool parsef(Print * stream,  int16_t params, int16_t p[]);
      static bool parseD(Print * stream,  int16_t params, int16_t p[]);
 


### PR DESCRIPTION
Extended `<s>` command.
Default `<s>` functionality maintained.

`<s p>` will broadcast current power states.
`<s v>` will return the CS version details.
`<s t>` will return turnout states.
`<s o>` will return output states.
`<s s>` will return sensor states.