### PR TITLE
Current measurement

### DIFF
--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -292,6 +292,15 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
             return;
         break;
 
+    case 'A': //switch current reporting on/off
+        if (params==2) { // <A MAINSTATUS PROGSTATUS>
+          {
+            DCCWaveform::mainTrack.setRMSMode(p[0], stream);
+            DCCWaveform::progTrack.setRMSMode(p[1], stream);
+          }
+          return;
+        }
+        break;
     case 'a': // ACCESSORY <a ADDRESS SUBADDRESS ACTIVATE> or <a LINEARADDRESS ACTIVATE>
         { 
           int address;
@@ -487,9 +496,16 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
 
     case 'c': // SEND METER RESPONSES <c>
         //                               <c MeterName value C/V unit min max res warn>
-        StringFormatter::send(stream, F("<c CurrentMAIN %d C Milli 0 %d 1 %d>\n"), DCCWaveform::mainTrack.getCurrentmA(), 
+        if (params==0) 
+        {
+          StringFormatter::send(stream, F("<c CurrentMAIN %d C Milli 0 %d 1 %d>\n"), round(DCCWaveform::mainTrack.getCurrentmA()),
             DCCWaveform::mainTrack.getMaxmA(), DCCWaveform::mainTrack.getTripmA());
-        StringFormatter::send(stream, F("<a %d>\n"), DCCWaveform::mainTrack.get1024Current()); //'a' message deprecated, remove once JMRI 4.22 is available
+//        StringFormatter::send(stream, F("<a %d>\n"), DCCWaveform::mainTrack.get1024Current()); //'a' message deprecated, remove once JMRI 4.22 is available
+        }
+        else
+          if (p[0]== 0)
+            StringFormatter::send(stream, F("<c CurrentMAIN %d %d C Milli 0 %d 1 %d>\n"), round(DCCWaveform::mainTrack.getCurrentRMS()), round(DCCWaveform::progTrack.getCurrentRMS()),
+              DCCWaveform::mainTrack.getMaxmA(), DCCWaveform::mainTrack.getTripmA());
         return;
 
     case 'Q': // SENSORS <Q>

--- a/DCCWaveform.cpp
+++ b/DCCWaveform.cpp
@@ -24,6 +24,7 @@
 
 #include <Arduino.h>
 
+#include "StringFormatter.h"
 #include "DCCWaveform.h"
 #include "DCCTimer.h"
 #include "DIAG.h"
@@ -134,10 +135,17 @@ void DCCWaveform::checkPowerOverload(bool ackManagerActive) {
   switch (powerMode) {
     case POWERMODE::OFF:
       sampleDelay = POWER_SAMPLE_OFF_WAIT;
+      if (sendCurrentSample || (accuSize > 0))
+        StringFormatter::send(outStream, F("<a %d %d>\n"), isMainTrack ? 0 : 1, 0);
       break;
     case POWERMODE::ON:
       // Check current
       lastCurrent=motorDriver->getCurrentRaw();
+      if (sendCurrentSample)
+        StringFormatter::send(outStream, F("<a %d %d>\n"), isMainTrack ? 0 : 1, getCurrentmA());
+      else
+        if (accuSize > 0)
+          currAccu = (currAccu * accuFact) + (sq((float)getCurrentmA()));
       if (lastCurrent < 0) {
 	  // We have a fault pin condition to take care of
 	  lastCurrent = -lastCurrent;

--- a/DCCWaveform.h
+++ b/DCCWaveform.h
@@ -72,6 +72,22 @@ class DCCWaveform {
         return motorDriver->raw2mA(lastCurrent);
       return 0;
     }
+    inline void setRMSMode(byte newMode, Print* stream) { //0: OFF 1: Broadcast mA Reading >1: Internal calc buffer size
+      outStream = stream;
+      sendCurrentSample = newMode == 1;
+      accuSize = newMode;
+      if (newMode > 1)
+      {
+        accuFact = (float)(newMode - 1) / newMode; 
+        currAccu = 0; 
+      }
+    }
+    inline float getCurrentRMS() {
+      if (accuSize == 0)
+        return 0;
+      else
+        return sqrt(currAccu / accuSize);
+    }
     inline int getMaxmA() {
       if (maxmA == 0) { //only calculate this for first request, it doesn't change
         maxmA = motorDriver->raw2mA(motorDriver->getRawCurrentTripValue()); //TODO: replace with actual max value or calc
@@ -101,6 +117,10 @@ class DCCWaveform {
     };
     inline bool canMeasureCurrent() {
       return motorDriver->canMeasureCurrent();
+    };
+    inline void setReportCurrent(bool newStatus, Print *stream) {
+      sendCurrentSample = newStatus;
+      outStream = stream;
     };
     inline void setAckLimit(int mA) {
 	ackLimitmA = mA;
@@ -153,6 +173,11 @@ class DCCWaveform {
     unsigned long power_sample_overload_wait = POWER_SAMPLE_OVERLOAD_WAIT;
     unsigned int power_good_counter = 0;
 
+    bool sendCurrentSample;
+    Print* outStream;
+    volatile double currAccu = 0;
+    byte accuSize = 0;
+    float accuFact = 0;
     // ACK management (Prog track only)  
     volatile bool ackPending;
     volatile bool ackDetected;


### PR DESCRIPTION
Change overview
1. Changes to the command reference
- <a xx> response removed from the <c> request response as suggested in source code note
- recycling of <a> for event driven reporting of current readings. Format: <a TRACK VALUE> with 0 for main track, 1 for prog track, VALUE is getCurrentmA(). <a could be changed to something else since <a is already used for incoming commands
- Introduction of <A MAINCURRENT PROGCURRENT> command. MAINCURRENT  and PROGCURRENT .control how current measurement is done for main and prog track. If 0, current measurement for the track is OFF. If set to 1, current readings are broadcasted using <a TRACK VALUE>, leading to 2 messages per 1/10 of a second. If set to > 1, current measurement is internal, with the number indicating the number of history values that are considered for rolling average. Example: <A 30 0> sets the current measurement for MAIN to internal with a buffer size of 30 values (about 3 secs), current measurement on PROG is OFF
- Introduction of <c 0> command, a modified form of <c>. It reports current from the internal measurement using the new getCurrentRMS() function. Same format as <c>, just two values for current reported based on the rolling RMS calculation

2. Measurement methodology
a) Internal
After each current measurement, the getCurrentmA() value is squared and added to a rolling average. When getCurrentRMS() is called, the rolling average is divided by buffer size and rounded sqrt is reported. This is the current in mA. Advantage is the calculation is done in DCC EX. Disadvantage is that due to the average calculation reaction of going down to zero is slow
b)  broadcast
After each current measurement, the getCurrentmA() result is sent to the serial interface. Processing of RMS calculation is done on the host computer where more memory is available to do a ring buffer for each track for the square values, leading to faster phase out if zero current. This is my preferred solution for the RedHat, would also work for JMRI