### PR TITLE
Reduce flash size usage when no LCD is used. -648 Bytes

### DIFF
--- a/CommandStation-EX.ino
+++ b/CommandStation-EX.ino
@@ -136,9 +136,11 @@ void loop()
   #if defined(LCN_SERIAL)
   LCN::loop();
   #endif
-
+  
+  #ifndef NO_LCD_USED
   LCDDisplay::loop();  // ignored if LCD not in use
-
+  #endif
+  
   // Handle/update IO devices.
   IODevice::loop();
 

--- a/LCD_Implementation.h
+++ b/LCD_Implementation.h
@@ -27,10 +27,14 @@
 
 #ifndef LCD_Implementation_h
 #define LCD_Implementation_h
-#include "LCDDisplay.h"
-#include "SSD1306Ascii.h"
-#include "LiquidCrystal_I2C.h"
-  
+#if !defined(OLED_DRIVER) && !defined(LCD_DRIVER)
+  #include "DisplayInterface.h"
+  #define NO_LCD_USED
+#else
+  #include "LCDDisplay.h"
+  #include "SSD1306Ascii.h"
+  #include "LiquidCrystal_I2C.h"
+#endif
 
 // Implement the LCDDisplay shim class as a singleton.
 // The DisplayInterface class implements a displayy handler with no code (null device);

--- a/StringFormatter.cpp
+++ b/StringFormatter.cpp
@@ -27,7 +27,7 @@
   Print * StringFormatter::diagSerial=&Serial;
 #endif
 
-#include "LCDDisplay.h"
+#include "LCD_Implementation.h"
 
 bool Diag::ACK=false;
 bool Diag::CMD=false;
@@ -47,6 +47,7 @@ void StringFormatter::diag( const FSH* input...) {
 }
 
 void StringFormatter::lcd(byte row, const FSH* input...) {
+#ifndef NO_LCD_USED
   va_list args;
 
   // Issue the LCD as a diag first
@@ -59,6 +60,7 @@ void StringFormatter::lcd(byte row, const FSH* input...) {
   LCDDisplay::lcdDisplay->setRow(row);    
   va_start(args, input);
   send2(LCDDisplay::lcdDisplay,input,args);
+#endif
 }
 
 void StringFormatter::send(Print * stream, const FSH* input...) {

--- a/StringFormatter.h
+++ b/StringFormatter.h
@@ -25,7 +25,6 @@
   #include <cstdarg>  
 #endif
 
-#include "LCDDisplay.h"
 class Diag {
   public:
   static bool ACK;


### PR DESCRIPTION
Also without a LCD, the file 'LCDDisplay.h' is included and so blows up the binary unnecessary. This pull request reduces the flash usage by 648 Bytes.