### PR TITLE
Exio-prevent-digital-analogue-conflict

### DIFF
--- a/IO_EXIOExpander.h
+++ b/IO_EXIOExpander.h
@@ -90,6 +90,8 @@ private:
       _majorVer = _versionBuffer[0];
       _minorVer = _versionBuffer[1];
       _patchVer = _versionBuffer[2];
+      DIAG(F("EX-IOExpander device found, I2C:x%x, Version v%d.%d.%d"),
+          _i2cAddress, _versionBuffer[0], _versionBuffer[1], _versionBuffer[2]);
 #ifdef DIAG_IO
       _display();
 #endif
@@ -102,6 +104,10 @@ private:
   bool _configure(VPIN vpin, ConfigTypeEnum configType, int paramCount, int params[]) override {
     if (configType != CONFIGURE_INPUT) return false;
     if (paramCount != 1) return false;
+    if (vpin >= _firstVpin + _numDigitalPins) {
+      DIAG(F("Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
+      return false;
+    }
     bool pullup = params[0];
     int pin = vpin - _firstVpin;
     _digitalOutBuffer[0] = EXIODPUP;
@@ -112,6 +118,10 @@ private:
   }
 
   int _readAnalogue(VPIN vpin) override {
+    if (vpin < _firstVpin + _numDigitalPins) {
+      DIAG(F("Vpin %d is a digital pin, cannot use as an analogue pin"), vpin);
+      return false;
+    }
     int pin = vpin - _firstVpin;
     _analogueOutBuffer[0] = EXIORDAN;
     _analogueOutBuffer[1] = pin;
@@ -120,6 +130,10 @@ private:
   }
 
   int _read(VPIN vpin) override {
+    if (vpin >= _firstVpin + _numDigitalPins) {
+      DIAG(F("Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
+      return false;
+    }
     int pin = vpin - _firstVpin;
     _digitalOutBuffer[0] = EXIORDD;
     _digitalOutBuffer[1] = pin;
@@ -129,6 +143,10 @@ private:
   }
 
   void _write(VPIN vpin, int value) override {
+    if (vpin >= _firstVpin + _numDigitalPins) {
+      DIAG(F("Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
+      return;
+    }
     int pin = vpin - _firstVpin;
     _digitalOutBuffer[0] = EXIOWRD;
     _digitalOutBuffer[1] = pin;

--- a/IO_EXIOExpander.h
+++ b/IO_EXIOExpander.h
@@ -105,7 +105,7 @@ private:
     if (configType != CONFIGURE_INPUT) return false;
     if (paramCount != 1) return false;
     if (vpin >= _firstVpin + _numDigitalPins) {
-      DIAG(F("Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
+      DIAG(F("EX-IOExpander ERROR: Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
       return false;
     }
     bool pullup = params[0];
@@ -117,11 +117,16 @@ private:
     return true;
   }
 
-  int _readAnalogue(VPIN vpin) override {
+  // We only use this to detect incorrect use of analogue pins
+  int _configureAnalogIn(VPIN vpin) override {
     if (vpin < _firstVpin + _numDigitalPins) {
-      DIAG(F("Vpin %d is a digital pin, cannot use as an analogue pin"), vpin);
-      return false;
+      DIAG(F("EX-IOExpander ERROR: Vpin %d is a digital pin, cannot use as an analogue pin"), vpin);
     }
+    return false;
+  }
+
+  int _readAnalogue(VPIN vpin) override {
+    if (vpin < _firstVpin + _numDigitalPins) return false;
     int pin = vpin - _firstVpin;
     _analogueOutBuffer[0] = EXIORDAN;
     _analogueOutBuffer[1] = pin;
@@ -130,10 +135,7 @@ private:
   }
 
   int _read(VPIN vpin) override {
-    if (vpin >= _firstVpin + _numDigitalPins) {
-      DIAG(F("Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
-      return false;
-    }
+    if (vpin >= _firstVpin + _numDigitalPins) return false;
     int pin = vpin - _firstVpin;
     _digitalOutBuffer[0] = EXIORDD;
     _digitalOutBuffer[1] = pin;
@@ -143,10 +145,7 @@ private:
   }
 
   void _write(VPIN vpin, int value) override {
-    if (vpin >= _firstVpin + _numDigitalPins) {
-      DIAG(F("Vpin %d is an analogue pin, cannot use as a digital pin"), vpin);
-      return;
-    }
+    if (vpin >= _firstVpin + _numDigitalPins) return;
     int pin = vpin - _firstVpin;
     _digitalOutBuffer[0] = EXIOWRD;
     _digitalOutBuffer[1] = pin;

--- a/IO_EXTurntable.h
+++ b/IO_EXTurntable.h
@@ -47,7 +47,7 @@ EXTurntable::EXTurntable(VPIN firstVpin, int nPins, uint8_t I2CAddress) {
   addDevice(this);
 }
 
-// Initialisation of TurntableEX
+// Initialisation of EXTurntable
 void EXTurntable::_begin() {
   I2CManager.begin();
   I2CManager.setClock(1000000);
@@ -103,7 +103,7 @@ void EXTurntable::_writeAnalogue(VPIN vpin, int value, uint8_t activity, uint16_
   uint8_t stepsMSB = value >> 8;
   uint8_t stepsLSB = value & 0xFF;
 #ifdef DIAG_IO
-  DIAG(F("TurntableEX WriteAnalogue Vpin:%d Value:%d Activity:%d Duration:%d"),
+  DIAG(F("EX-Turntable WriteAnalogue Vpin:%d Value:%d Activity:%d Duration:%d"),
     vpin, value, activity, duration);
   DIAG(F("I2CManager write I2C Address:%d stepsMSB:%d stepsLSB:%d activity:%d"),
     _I2CAddress, stepsMSB, stepsLSB, activity);
@@ -114,7 +114,7 @@ void EXTurntable::_writeAnalogue(VPIN vpin, int value, uint8_t activity, uint16_
 
 // Display Turnetable-EX device driver info.
 void EXTurntable::_display() {
-  DIAG(F("TurntableEX I2C:x%x Configured on Vpins:%d-%d %S"), _I2CAddress, (int)_firstVpin, 
+  DIAG(F("EX-Turntable I2C:x%x Configured on Vpins:%d-%d %S"), _I2CAddress, (int)_firstVpin, 
     (int)_firstVpin+_nPins-1, (_deviceState==DEVSTATE_FAILED) ? F("OFFLINE") : F(""));
 }
 


### PR DESCRIPTION
Cosmetic change to EX-Turntable diag message.

Added logic to prevent any pins defined as digital being used as analogue pins and vice versa in the EX-IOExpander device driver.