### PR TITLE
[ESP32] Use GPIO 35/A2 and 34/A3 for current sensing

### DIFF
--- a/MotorDrivers.h
+++ b/MotorDrivers.h
@@ -73,12 +73,12 @@
 #elif defined(ARDUINO_ARCH_ESP32)
 // STANDARD shield on an ESPDUINO-32 (ESP32 in Uno form factor). The shield must be eiter the
 // 3.3V compatible R3 version or it has to be modified to not supply more than 3.3V to the
-// analog inputs. Here we use analog inputs A4 and A5 as A0 and A1 are wired in a way so that
+// analog inputs. Here we use analog inputs A2 and A3 as A0 and A1 are wired in a way so that
 // they are not useable at the same time as WiFi (what a bummer). The numbers below are the
 // actual GPIO numbers. In comments the numbers the pins have on an Uno.
 #define STANDARD_MOTOR_SHIELD F("STANDARD_MOTOR_SHIELD"),                                                 \
-    new MotorDriver(25/* 3*/, 19/*12*/, UNUSED_PIN, 13/*9*/, 36/*A4*/, 0.70, 1500, UNUSED_PIN), \
-    new MotorDriver(23/*11*/, 18/*13*/, UNUSED_PIN, 12/*8*/, 39/*A5*/, 0.70, 1500, UNUSED_PIN)
+    new MotorDriver(25/* 3*/, 19/*12*/, UNUSED_PIN, 13/*9*/, 35/*A2*/, 0.70, 1500, UNUSED_PIN), \
+    new MotorDriver(23/*11*/, 18/*13*/, UNUSED_PIN, 12/*8*/, 34/*A3*/, 0.70, 1500, UNUSED_PIN)
 
 #else
 // STANDARD shield on any Arduino Uno or Mega compatible with the original specification.

--- a/version.h
+++ b/version.h
@@ -5,13 +5,14 @@
 
 
 #define VERSION "4.2.36rc1"
-// 4.2.36 - do not broadcast a turnout state that has not changed
-// 4.2.35 - add <z> direct pin manipulation command 
+// 4.2.36 - Do not broadcast a turnout state that has not changed
+//        - Use A2/A3 for current sensing on ESP32 + Motor Shield
+// 4.2.35 - add <z> direct pin manipulation command
 // 4.2.34 - Completely fix EX-IOExpander analogue inputs
 // 4.2.33 - Fix EX-IOExpander non-working analogue inputs
 // 4.2.32 - Fix LCD/Display bugfixes from 4.2.29
 // 4.2.31 - Removes EXRAIL statup from top of file. (BREAKING CHANGE !!)
-//          Just add AUTOSTART to the top of your myAutomation.h to restore this function. 
+//          Just add AUTOSTART to the top of your myAutomation.h to restore this function.
 // 4.2.30 - Fixes/enhancements to EX-IOExpander device driver.
 // 4.2.29 - Bugfix Scroll LCD without empty lines and consistent
 // 4.2.28 - Reinstate use of timer11 in STM32 - remove HA mode.


### PR DESCRIPTION
As suggested by @habazut over discord and looking at the Motor Shield schematics, A2 / A3 (which map to GPIO35 and GPIO34 on the Wemos D1 R32) better fit the current sensing purpose rather than GPIO36 and GPIO39

![image](https://user-images.githubusercontent.com/1818657/227731268-67afc8e9-c7c3-4418-835b-770425b58f82.png)

![Wemos+MS](https://user-images.githubusercontent.com/1818657/227731148-770c52dd-b5ba-4038-9e25-e1c25e19fcb8.png)


