### PR TITLE
Added disable logic

### DIFF
--- a/IODevice.cpp
+++ b/IODevice.cpp
@@ -63,15 +63,31 @@ void IODevice::begin() {
   if (exrailHalSetup)
     exrailHalSetup();
 
-  // Predefine two PCA9685 modules 0x40-0x41
+  // Predefine two PCA9685 modules 0x40-0x41 if no conflicts
   // Allocates 32 pins 100-131
-  PCA9685::create(100, 16, 0x40);
-  PCA9685::create(116, 16, 0x41);
+  if (checkNoOverlap(100, 16, 0x40)) {
+    PCA9685::create(100, 16, 0x40);
+  } else {
+    DIAG(F("Default PCA9685 at I2C 0x40 disabled due to configured user device"));
+  }
+  if (checkNoOverlap(116, 16, 0x41)) {
+    PCA9685::create(116, 16, 0x41);
+  } else {
+    DIAG(F("Default PCA9685 at I2C 0x41 disabled due to configured user device"));
+  }
   
-  // Predefine two MCP23017 module 0x20/0x21
+  // Predefine two MCP23017 module 0x20/0x21 if no conflicts
   // Allocates 32 pins 164-195
-  MCP23017::create(164, 16, 0x20);
-  MCP23017::create(180, 16, 0x21);
+  if (checkNoOverlap(164, 16, 0x20)) {
+    MCP23017::create(164, 16, 0x20);
+  } else {
+    DIAG(F("Default MCP23017 at I2C 0x20 disabled due to configured user device"));
+  }
+  if (checkNoOverlap(180, 16, 0x21)) {
+    MCP23017::create(180, 16, 0x21);
+  } else {
+    DIAG(F("Default MCP23017 at I2C 0x21 disabled due to configured user device"));
+  }
 }
 
 // reset() function to reinitialise all devices

--- a/version.h
+++ b/version.h
@@ -4,7 +4,8 @@
 #include "StringFormatter.h"
 
 
-#define VERSION "4.2.39"
+#define VERSION "4.2.40"
+// 4.2.40 - Automatically detect conflicting default I2C devices and disable
 // 4.2.39 - DFplayer driver now polls device to detect failures and errors.
 // 4.2.38 - Clean up compiler warning when IO_RotaryEncoder.h included
 // 4.2.37 - Add new FLAGS HAL device for communications to/from EX-RAIL;


### PR DESCRIPTION
Added logic to skip default PCA9685/MCP23017 devices if any addresses or Vpins are already defined by user devices.