### PR TITLE
RotaryEnoder, EX-Turntable fixes

### DIFF
--- a/IO_EXTurntable.h
+++ b/IO_EXTurntable.h
@@ -50,12 +50,12 @@ EXTurntable::EXTurntable(VPIN firstVpin, int nPins, I2CAddress I2CAddress) {
 // Initialisation of EXTurntable
 void EXTurntable::_begin() {
   I2CManager.begin();
-  I2CManager.setClock(1000000);
   if (I2CManager.exists(_I2CAddress)) {
 #ifdef DIAG_IO
     _display();
 #endif
   } else {
+    DIAG(F("EX-Turntable I2C:%s device not found"), _I2CAddress.toString());
     _deviceState = DEVSTATE_FAILED;
   }
 }

--- a/IO_RotaryEncoder.h
+++ b/IO_RotaryEncoder.h
@@ -134,12 +134,13 @@ private:
     }
   }
 
-  // Device specific read function
+  // Return the position sent by the rotary encoder software
   int _readAnalogue(VPIN vpin) override {
     if (_deviceState == DEVSTATE_FAILED) return 0;
     return _position;
   }
 
+  // Send the feedback value to the rotary encoder software
   void _write(VPIN vpin, int value) override {
     if (vpin == _firstVpin + 1) {
       if (value != 0) value = 0x01;
@@ -148,9 +149,12 @@ private:
     }
   }
 
+  // Send a position update to the rotary encoder software
+  // To be valid, must be 0 to 255, and different to the current position
+  // If the current position is the same, it was initiated by the rotary encoder
   void _writeAnalogue(VPIN vpin, int position, uint8_t profile, uint16_t duration) override {
     if (vpin == _firstVpin + 2) {
-      if (position >= 0 && position <= 255) {
+      if (position >= 0 && position <= 255 && position != _position) {
         byte newPosition = position & 0xFF;
         byte _positionBuffer[2] = {RE_MOVE, newPosition};
         I2CManager.write(_I2CAddress, _positionBuffer, 2);

--- a/version.h
+++ b/version.h
@@ -4,7 +4,10 @@
 #include "StringFormatter.h"
 
 
-#define VERSION "4.2.61"
+#define VERSION "4.2.62"
+// 4.2.62 - Update IO_RotaryEncoder.h to ignore sending current position
+//        - Update IO_EXTurntable.h to remove forced I2C clock speed
+//        - Show device offline if EX-Turntable not connected
 // 4.2.61 - MAX_CURRENT restriction (caps motor shield value)
 // 4.2.60 - Add mDNS capability to ESP32 for autodiscovery
 // 4.2.59 - Fix: AP SSID was DCC_ instead of DCCEX_


### PR DESCRIPTION
Update IO_RotaryEncoder.h to ignore sending current position
Update IO_EXTurntable.h to remove forced I2C clock speed and show device offline if EX-Turntable not connected