### PR TITLE
Separate-hal-extt-turntable

### DIFF
--- a/EXRAIL2MacroReset.h
+++ b/EXRAIL2MacroReset.h
@@ -196,7 +196,7 @@
 #define ENDTASK
 #define ESTOP 
 #define EXRAIL
-#define EXTT_TURNTABLE(id,vpin,i2c_address,home,description)
+#define EXTT_TURNTABLE(id,home,description)
 #define FADE(pin,value,ms)
 #define FOFF(func)
 #define FOLLOW(route) 

--- a/EXRAIL2MacroReset.h
+++ b/EXRAIL2MacroReset.h
@@ -196,7 +196,7 @@
 #define ENDTASK
 #define ESTOP 
 #define EXRAIL
-#define EXTT_TURNTABLE(id,home,description)
+#define EXTT_TURNTABLE(id,vpin,home,description)
 #define FADE(pin,value,ms)
 #define FOFF(func)
 #define FOLLOW(route) 

--- a/EXRAILMacros.h
+++ b/EXRAILMacros.h
@@ -79,8 +79,6 @@
 #include "EXRAIL2MacroReset.h"
 #undef HAL
 #define HAL(haltype,params...)  haltype::create(params);
-#undef EXTT_TURNTABLE
-#define EXTT_TURNTABLE(id,vpin,i2c_address,home,description...) EXTurntable::create(vpin,1,i2c_address);
 void exrailHalSetup() {
    #include "myAutomation.h"
 }
@@ -226,7 +224,7 @@ const FSH * RMFT2::getTurnoutDescription(int16_t turnoutid) {
 #undef DCC_TURNTABLE
 #define DCC_TURNTABLE(id,home,description...) O_DESC(id,description)
 #undef EXTT_TURNTABLE
-#define EXTT_TURNTABLE(id,vpin,i2c_address,home,description...) O_DESC(id,description)
+#define EXTT_TURNTABLE(id,home,description...) O_DESC(id,description)
 
 const FSH * RMFT2::getTurntableDescription(int16_t turntableId) {
    switch (turntableId) {
@@ -356,7 +354,7 @@ int RMFT2::onLCCLookup[RMFT2::countLCCLookup];
 #define ESTOP OPCODE_SPEED,V(1), 
 #define EXRAIL
 #ifndef IO_NO_HAL
-#define EXTT_TURNTABLE(id,vpin,i2c_address,home,description...) OPCODE_EXTTTURNTABLE,V(id),OPCODE_PAD,V(vpin),OPCODE_PAD,V(i2c_address),OPCODE_PAD,V(home),
+#define EXTT_TURNTABLE(id,home,description...) OPCODE_EXTTTURNTABLE,V(id),OPCODE_PAD,V(home),
 #endif
 #define FADE(pin,value,ms) OPCODE_SERVO,V(pin),OPCODE_PAD,V(value),OPCODE_PAD,V(PCA9685::ProfileType::UseDuration|PCA9685::NoPowerOff),OPCODE_PAD,V(ms/100L),
 #define FOFF(func) OPCODE_FOFF,V(func),

--- a/EXRAILMacros.h
+++ b/EXRAILMacros.h
@@ -224,7 +224,7 @@ const FSH * RMFT2::getTurnoutDescription(int16_t turnoutid) {
 #undef DCC_TURNTABLE
 #define DCC_TURNTABLE(id,home,description...) O_DESC(id,description)
 #undef EXTT_TURNTABLE
-#define EXTT_TURNTABLE(id,home,description...) O_DESC(id,description)
+#define EXTT_TURNTABLE(id,vpin,home,description...) O_DESC(id,description)
 
 const FSH * RMFT2::getTurntableDescription(int16_t turntableId) {
    switch (turntableId) {
@@ -354,7 +354,7 @@ int RMFT2::onLCCLookup[RMFT2::countLCCLookup];
 #define ESTOP OPCODE_SPEED,V(1), 
 #define EXRAIL
 #ifndef IO_NO_HAL
-#define EXTT_TURNTABLE(id,home,description...) OPCODE_EXTTTURNTABLE,V(id),OPCODE_PAD,V(home),
+#define EXTT_TURNTABLE(id,vpin,home,description...) OPCODE_EXTTTURNTABLE,V(id),OPCODE_PAD,V(vpin),OPCODE_PAD,V(home),
 #endif
 #define FADE(pin,value,ms) OPCODE_SERVO,V(pin),OPCODE_PAD,V(value),OPCODE_PAD,V(PCA9685::ProfileType::UseDuration|PCA9685::NoPowerOff),OPCODE_PAD,V(ms/100L),
 #define FOFF(func) OPCODE_FOFF,V(func),

--- a/Turntables.cpp
+++ b/Turntables.cpp
@@ -183,7 +183,7 @@ using DevState = IODevice::DeviceStateEnum;
         return tto;
       }
     }
-    // if (!IODevice::exists(vpin)) return nullptr;
+    if (!IODevice::exists(vpin)) return nullptr;
     if (IODevice::getStatus(vpin) == DevState::DEVSTATE_FAILED) return nullptr;
     if (Turntable::getByVpin(vpin)) return nullptr;
     tto = (Turntable *)new EXTTTurntable(id, vpin);

--- a/Turntables.cpp
+++ b/Turntables.cpp
@@ -183,7 +183,7 @@ using DevState = IODevice::DeviceStateEnum;
         return tto;
       }
     }
-    if (!IODevice::exists(vpin)) return nullptr;
+    // if (!IODevice::exists(vpin)) return nullptr;
     if (IODevice::getStatus(vpin) == DevState::DEVSTATE_FAILED) return nullptr;
     if (Turntable::getByVpin(vpin)) return nullptr;
     tto = (Turntable *)new EXTTTurntable(id, vpin);

--- a/version.h
+++ b/version.h
@@ -3,7 +3,8 @@
 
 #include "StringFormatter.h"
 
-#define VERSION "5.1.15"
+#define VERSION "5.1.16"
+// 5.1.16 - Change EXTT_TURNTABLE to use HAL and remove vpin/i2c_address
 // 5.1.15 - LCC/Adapter support and Exrail feature-compile-out.
 // 5.1.14 - Fixed IFTTPOSITION
 // 5.1.13 - Changed turntable broadcast from i to I due to server string conflict

--- a/version.h
+++ b/version.h
@@ -4,7 +4,7 @@
 #include "StringFormatter.h"
 
 #define VERSION "5.1.16"
-// 5.1.16 - Change EXTT_TURNTABLE to use HAL and remove vpin/i2c_address
+// 5.1.16 - Remove I2C address from EXTT_TURNTABLE macro to work with MUX, requires separate HAL macro to create
 // 5.1.15 - LCC/Adapter support and Exrail feature-compile-out.
 // 5.1.14 - Fixed IFTTPOSITION
 // 5.1.13 - Changed turntable broadcast from i to I due to server string conflict


### PR DESCRIPTION
Remove I2C address from EXTT_TURNTABLE macro so it will work with a  MUX. Now requires extra HAL macro first.