### PR TITLE
Ex-ioexpander-no-analogue-pins-fix

### DIFF
--- a/IO_EXIOExpander.h
+++ b/IO_EXIOExpander.h
@@ -22,13 +22,10 @@
 * This device driver will configure the device on startup, along with
 * interacting with the device for all input/output duties.
 *
-* To create EX-IOExpander devices, these are defined in myHal.cpp:
+* To create EX-IOExpander devices, these are defined in myAutomation.h:
 * (Note the device driver is included by default)
 *
-* void halSetup() {
-*   // EXIOExpander::create(vpin, num_vpins, i2c_address);
-*   EXIOExpander::create(800, 18, 0x65);
-* }
+* HAL(EXIOExpander,800,18,0x65)
 * 
 * All pins on an EX-IOExpander device are allocated according to the pin map for the specific
 * device in use. There is no way for the device driver to sanity check pins are used for the
@@ -98,25 +95,30 @@ private:
           _numAnaloguePins = receiveBuffer[2];
 
           // See if we already have suitable buffers assigned
-          size_t digitalBytesNeeded = (_numDigitalPins + 7) / 8;
-          if (_digitalPinBytes < digitalBytesNeeded) {
-            // Not enough space, free any existing buffer and allocate a new one
-            if (_digitalPinBytes > 0) free(_digitalInputStates);
-            _digitalInputStates = (byte*) calloc(_digitalPinBytes, 1);
-            _digitalPinBytes = digitalBytesNeeded;
-          }
-          size_t analogueBytesNeeded = _numAnaloguePins * 2;
-          if (_analoguePinBytes < analogueBytesNeeded) {
-            // Free any existing buffers and allocate new ones.
-            if (_analoguePinBytes > 0) {
-              free(_analogueInputBuffer);
-              free(_analogueInputStates);
-              free(_analoguePinMap);
+          if (_numDigitalPins>0) {
+            size_t digitalBytesNeeded = (_numDigitalPins + 7) / 8;
+            if (_digitalPinBytes < digitalBytesNeeded) {
+              // Not enough space, free any existing buffer and allocate a new one
+              if (_digitalPinBytes > 0) free(_digitalInputStates);
+              _digitalInputStates = (byte*) calloc(_digitalPinBytes, 1);
+              _digitalPinBytes = digitalBytesNeeded;
             }
-            _analogueInputStates = (uint8_t*) calloc(analogueBytesNeeded, 1);
-            _analogueInputBuffer = (uint8_t*) calloc(analogueBytesNeeded, 1);
-            _analoguePinMap = (uint8_t*) calloc(_numAnaloguePins, 1);
-            _analoguePinBytes = analogueBytesNeeded;
+          }
+          
+          if (_numAnaloguePins>0) {
+            size_t analogueBytesNeeded = _numAnaloguePins * 2;
+            if (_analoguePinBytes < analogueBytesNeeded) {
+              // Free any existing buffers and allocate new ones.
+              if (_analoguePinBytes > 0) {
+                free(_analogueInputBuffer);
+                free(_analogueInputStates);
+                free(_analoguePinMap);
+              }
+              _analogueInputStates = (uint8_t*) calloc(analogueBytesNeeded, 1);
+              _analogueInputBuffer = (uint8_t*) calloc(analogueBytesNeeded, 1);
+              _analoguePinMap = (uint8_t*) calloc(_numAnaloguePins, 1);
+              _analoguePinBytes = analogueBytesNeeded;
+            }
           }
         } else {
           DIAG(F("EX-IOExpander I2C:%s ERROR configuring device"), _I2CAddress.toString());
@@ -124,8 +126,8 @@ private:
           return;
         }
       } 
-      // We now need to retrieve the analogue pin map
-      if (status == I2C_STATUS_OK) {
+      // We now need to retrieve the analogue pin map if there are analogue pins
+      if (status == I2C_STATUS_OK && _numAnaloguePins>0) {
         commandBuffer[0] = EXIOINITA;
         status = I2CManager.read(_I2CAddress, _analoguePinMap, _numAnaloguePins, commandBuffer, 1);
       }
@@ -239,7 +241,7 @@ private:
 
     // If we're not doing anything now, check to see if a new input transfer is due.
     if (_readState == RDS_IDLE) {
-      if (currentMicros - _lastDigitalRead > _digitalRefresh) { // Delay for digital read refresh
+      if (currentMicros - _lastDigitalRead > _digitalRefresh && _numDigitalPins>0) { // Delay for digital read refresh
         // Issue new read request for digital states.  As the request is non-blocking, the buffer has to
         // be allocated from heap (object state).
         _readCommandBuffer[0] = EXIORDD;
@@ -247,7 +249,7 @@ private:
                                                                 // non-blocking read
         _lastDigitalRead = currentMicros;
         _readState = RDS_DIGITAL;
-      } else if (currentMicros - _lastAnalogueRead > _analogueRefresh) { // Delay for analogue read refresh
+      } else if (currentMicros - _lastAnalogueRead > _analogueRefresh && _numAnaloguePins>0) { // Delay for analogue read refresh
         // Issue new read for analogue input states
         _readCommandBuffer[0] = EXIORDAN;
         I2CManager.read(_I2CAddress, _analogueInputBuffer,

--- a/version.h
+++ b/version.h
@@ -3,7 +3,8 @@
 
 #include "StringFormatter.h"
 
-#define VERSION "5.2.15"
+#define VERSION "5.2.16"
+// 5.2.16 - Bugfix to allow for devices using the EX-IOExpander protocol to have no analogue or no digital pins
 // 5.2.15 - move call to CommandDistributor::broadcastPower() into the TrackManager::setTrackPower(*) functions
 //        - add repeats to function packets that are not reminded in accordance with accessory packets
 // 5.2.14 - Reminder window DCC packet optimization


### PR DESCRIPTION
Update EX-IOExpander to cater for devices with either no analogue pins, or no digital pins.