### PR TITLE
Add - Firmware packaging & tests on Wokwi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,82 @@
-name: CI
+name: PlatformIO CI
 
 on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Python Wheel
-      run: pip install wheel
-    - name: Install PlatformIO Core
-      run: pip install -U platformio
-    - name: Copy generic config over
-      run: cp config.example.h config.h
-    - name: Compile Command Station (AVR)
-      run: python -m platformio run
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Use sample "config.example.h" for compilations
+        run: mv $GITHUB_WORKSPACE/config.example.h $GITHUB_WORKSPACE/config.h
+
+      - name: Build PlatformIO Project
+        run: pio run
+
+      - name: Copy all firmwares for for packaging
+        run: |
+          mkdir downloads
+          cd .pio/build
+          find . -name '*.bin' | cpio -pdm ../../downloads
+          find . -name '*.hex' | cpio -pdm ../../downloads
+          find . -name '*.uf2' | cpio -pdm ../../downloads
+          cd ../..
+
+      - name: Package and upload all firmwares for download
+        uses: actions/upload-artifact@v3
+        with: 
+          name: all-firmwares-for-download
+          path: downloads
+
+      - name: Test on Arduino MEGA with Wokwi
+        uses: wokwi/wokwi-ci-action@v1
+        with:
+          token: ${{ secrets.WOKWI_CLI_TOKEN }}
+          path: /wokwi/mega # directory with wokwi.toml, relative to repo's root
+          timeout: 10000
+          expect_text: '<* LCD3:Free RAM='
+          fail_text: 'Error'
+#          scenario: 'test-hello-world.yaml' # optional
+
+      - name: Test on Arduino UNO with Wokwi
+        uses: wokwi/wokwi-ci-action@v1
+        with:
+          token: ${{ secrets.WOKWI_CLI_TOKEN }}
+          path: /wokwi/uno # directory with wokwi.toml, relative to repo's root
+          timeout: 10000
+          expect_text: '<* LCD3:Free RAM='
+          fail_text: 'Error'
+#          scenario: 'test-hello-world.yaml' # optional
+
+      - name: Test on Arduino NANO with Wokwi
+        uses: wokwi/wokwi-ci-action@v1
+        with:
+          token: ${{ secrets.WOKWI_CLI_TOKEN }}
+          path: /wokwi/nano # directory with wokwi.toml, relative to repo's root
+          timeout: 10000
+          expect_text: '<* LCD3:Free RAM='
+          fail_text: 'Error'
+#          scenario: 'test-hello-world.yaml' # optional
+      
+      - name: Test on ESP32 with Wokwi
+        uses: wokwi/wokwi-ci-action@v1
+        with:
+          token: ${{ secrets.WOKWI_CLI_TOKEN }}
+          path: /wokwi/esp32 # directory with wokwi.toml, relative to repo's root
+          timeout: 10000
+          expect_text: 'ESP32 / STANDARD_MOTOR_SHIELD'
+          fail_text: 'Error'
+#          scenario: 'test-hello-world.yaml' # optional

--- a/wokwi/esp32/diagram.json
+++ b/wokwi/esp32/diagram.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "author": "Olivier Chatelain",
+  "editor": "wokwi",
+  "parts": [ { "type": "board-esp32-devkit-c-v4", "id": "esp", "top": 0, "left": 0, "attrs": {} } ],
+  "connections": [ [ "esp:TX", "$serialMonitor:RX", "", [] ], [ "esp:RX", "$serialMonitor:TX", "", [] ] ],
+  "dependencies": {}
+}

--- a/wokwi/esp32/wokwi.toml
+++ b/wokwi/esp32/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '../../.pio/build/ESP32/firmware.bin'
+elf = '../../.pio/build/ESP32/firmware.elf'

--- a/wokwi/mega/diagram.json
+++ b/wokwi/mega/diagram.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "author": "Olivier Chatelain",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "wokwi-arduino-mega", "id": "mega", "top": -249, "left": -147.6, "attrs": {} },
+    { "type": "wokwi-logic-analyzer", "id": "logic1", "top": -374.05, "left": 355.2, "attrs": {} },
+    {
+      "type": "board-ssd1306",
+      "id": "oled1",
+      "top": -409.66,
+      "left": 57.83,
+      "attrs": { "i2cAddress": "0x3c" }
+    },
+    { "type": "wokwi-gnd", "id": "gnd1", "top": -268.8, "left": 335.4, "attrs": {} },
+    { "type": "wokwi-gnd", "id": "gnd2", "top": -57.6, "left": 239.4, "attrs": {} },
+    {
+      "type": "wokwi-resistor",
+      "id": "r1",
+      "top": -476.6,
+      "left": 152.75,
+      "rotate": 270,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r2",
+      "top": -476.6,
+      "left": 75.95,
+      "rotate": 270,
+      "attrs": { "value": "1000" }
+    }
+  ],
+  "connections": [
+    [ "mega:GND.1", "oled1:GND", "black", [ "v0" ] ],
+    [ "mega:5V", "oled1:VCC", "red", [ "v-348.3", "h88.55" ] ],
+    [ "gnd1:GND", "logic1:GND", "black", [ "v0" ] ],
+    [ "mega:GND.5", "gnd2:GND", "black", [ "v0" ] ],
+    [ "oled1:SCL", "r2:1", "green", [ "v0" ] ],
+    [ "oled1:SDA", "r1:1", "green", [ "v0" ] ],
+    [ "r2:2", "oled1:VCC", "green", [ "h38.4", "v87.6", "h-38.4" ] ],
+    [ "r2:2", "r1:2", "green", [ "h0" ] ],
+    [ "mega:SCL", "oled1:SCL", "green", [ "v-144", "h172.5" ] ],
+    [ "mega:SDA", "oled1:SDA", "green", [ "v-134.4", "h162.8" ] ]
+  ],
+  "dependencies": {}
+}

--- a/wokwi/mega/wokwi.toml
+++ b/wokwi/mega/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '../../.pio/build/mega2560/firmware.hex'
+elf = '../../.pio/build/mega2560/firmware.elf'

--- a/wokwi/nano/diagram.json
+++ b/wokwi/nano/diagram.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "author": "Olivier Chatelain",
+  "editor": "wokwi",
+  "parts": [ { "type": "wokwi-arduino-nano", "id": "nano", "top": 0, "left": 0, "attrs": {} } ],
+  "connections": [],
+  "dependencies": {}
+}

--- a/wokwi/nano/wokwi.toml
+++ b/wokwi/nano/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '../../.pio/build/nano/firmware.hex'
+elf = '../../.pio/build/nano/firmware.elf'

--- a/wokwi/uno/diagram.json
+++ b/wokwi/uno/diagram.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "author": "Olivier Chatelain",
+  "editor": "wokwi",
+  "parts": [ { "type": "wokwi-arduino-uno", "id": "uno", "top": 0, "left": 0, "attrs": {} } ],
+  "connections": [],
+  "dependencies": {}
+}

--- a/wokwi/uno/wokwi.toml
+++ b/wokwi/uno/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '../../.pio/build/uno/firmware.hex'
+elf = '../../.pio/build/uno/firmware.elf'


### PR DESCRIPTION
The GitHub action is changed:
- Newer version of Checkout Action
- Caching of PlatformIO files
- All build firmwares (.bin / .hex) are bundles into a files
- All firmwares runnable on Wokwi are run as simulation

n.b.: To run on Wokwi a secret credetial has to be stored on the account.