### PR TITLE
Add-startup-delay

### DIFF
--- a/CommandStation-EX.ino
+++ b/CommandStation-EX.ino
@@ -78,7 +78,8 @@ void setup()
 
 // If user has defined a startup delay, delay here before starting IO
 #if defined(STARTUP_DELAY)
-  delay(STARTUP_DELAY)
+  DIAG(F("Delaying startup for %dms"), STARTUP_DELAY);
+  delay(STARTUP_DELAY);
 #endif
 
 // Initialise HAL layer before reading EEprom or setting up MotorDrivers 

--- a/CommandStation-EX.ino
+++ b/CommandStation-EX.ino
@@ -76,6 +76,11 @@ void setup()
 
   DIAG(F("License GPLv3 fsf.org (c) dcc-ex.com"));
 
+// If user has defined a startup delay, delay here before starting IO
+#if defined(STARTUP_DELAY)
+  delay(STARTUP_DELAY)
+#endif
+
 // Initialise HAL layer before reading EEprom or setting up MotorDrivers 
   IODevice::begin();
 

--- a/config.example.h
+++ b/config.example.h
@@ -223,6 +223,14 @@ The configuration file for DCC-EX Command Station
 // at the same time, there must be a border.
 
 /////////////////////////////////////////////////////////////////////////////////////
+// Some newer 32bit microcontrollers boot very quickly, so powering on I2C and other
+// peripheral devices at the same time may result in the CommandStation booting too
+// quickly to detect them.
+// To work around this, uncomment the STARTUP_DELAY line below and set a value in
+// milliseconds that works for your environment, default is 3000 (3 seconds).
+// #define STARTUP_DELAY 3000
+
+/////////////////////////////////////////////////////////////////////////////////////
 //
 // DEFINE TURNOUTS/ACCESSORIES FOLLOW NORM RCN-213
 //

--- a/version.h
+++ b/version.h
@@ -3,7 +3,8 @@
 
 #include "StringFormatter.h"
 
-#define VERSION "5.2.20"
+#define VERSION "5.2.21"
+// 5.2.21 - Add STARTUP_DELAY config option to delay CS bootup
 // 5.2.20 - Check return of Ethernet.begin()
 // 5.2.19 - ESP32: Determine if the RMT hardware can handle DCC
 // 5.2.18 - Display network IP fix


### PR DESCRIPTION
Add #define STARTUP_DELAY 3000 option so faster uCs can start after peripherals and accessories to improve reliablity.