### PR TITLE
RailCom cutout for MAIN and PROG track

### DIFF
--- a/DCCWaveform.h
+++ b/DCCWaveform.h
@@ -33,9 +33,9 @@
 
 
 // Number of preamble bits.
-const int   PREAMBLE_BITS_MAIN = 16;
-const int   PREAMBLE_BITS_PROG = 22;
-const byte   MAX_PACKET_SIZE = 5;  // NMRA standard extended packets, payload size WITHOUT checksum.
+const int   PREAMBLE_BITS_MAIN = 16; 
+const int   PREAMBLE_BITS_PROG = 22; 
+const byte  MAX_PACKET_SIZE = 5;  // NMRA standard extended packets, payload size WITHOUT checksum.
 
 
 // The WAVE_STATE enum is deliberately numbered because a change of order would be catastrophic
@@ -52,6 +52,11 @@ class DCCWaveform {
     static void loop();
     static DCCWaveform  mainTrack;
     static DCCWaveform  progTrack;
+    
+    static bool supportsRailcom;
+    static bool useRailcom;
+    static bool setUseRailcom(bool on); 
+    
     inline void clearRepeats() { transmitRepeats=0; }
 #ifndef ARDUINO_ARCH_ESP32
     inline void clearResets() { sentResetsSincePacket=0; }
@@ -87,6 +92,7 @@ class DCCWaveform {
 #endif
     static void interruptHandler();
     void interrupt2();
+    void railcom2();
     
     bool isMainTrack;
     // Transmission controller

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -51,9 +51,11 @@ class TrackManager {
                  );
     
     static void setDCCSignal( bool on);
-    static void setCutout( bool on);
     static void setPROGSignal( bool on);
     static void setDCSignal(int16_t cab, byte speedbyte);
+    static void setCutout( bool on,bool interruptContext=false);
+    static void setPROGCutout( bool on,bool interruptContext=false);
+    static bool isRailcomCapable();
     static MotorDriver * getProgDriver();
 #ifdef ARDUINO_ARCH_ESP32
   static std::vector<MotorDriver *>getMainDrivers();


### PR DESCRIPTION
Generates RailCom cutout signals on MAIN and PROG track, successfuly tested on Arduino Mega2560 with the standard motorshield and RailComDisplay by Paco.