### PR TITLE
Add ArduinoOTA Support for ESP32-Based Boards

### DIFF
--- a/config.example.h
+++ b/config.example.h
@@ -5,7 +5,7 @@
  *  © 2020-2021 Fred Decker
  *  © 2020-2021 Chris Harlow
  *  © 2023 Nathan Kellenicki
- *  
+ *
  *  This file is part of CommandStation-EX
  *
  *  This is free software: you can redistribute it and/or modify
@@ -32,7 +32,7 @@ The configuration file for DCC-EX Command Station
 // If you want to add your own motor driver definition(s), add them here
 //   For example MY_SHIELD with display name "MINE":
 //   (remove comment start and end marker if you want to edit and use that)
-/* 
+/*
 #define MY_SHIELD F("MINE"), \
  new MotorDriver( 3, 12, UNUSED_PIN, 9, A0, 5.08, 3000, A4), \
  new MotorDriver(11, 13, UNUSED_PIN, 8, A1, 5.08, 1500, A5)
@@ -50,7 +50,7 @@ The configuration file for DCC-EX Command Station
 //  STANDARD_MOTOR_SHIELD : Arduino Motor shield Rev3 based on the L298 with 18V 2A per channel
 //  POLOLU_MOTOR_SHIELD   : Pololu MC33926 Motor Driver (not recommended for prog track)
 //  FUNDUMOTO_SHIELD      : Fundumoto Shield, no current sensing (not recommended, no short protection)
-//  FIREBOX_MK1           : The Firebox MK1                    
+//  FIREBOX_MK1           : The Firebox MK1
 //  FIREBOX_MK1S          : The Firebox MK1S
 //  IBT_2_WITH_ARDUINO    : Arduino Motor Shield for PROG and IBT-2 for MAIN
 //  EX8874_SHIELD         : DCC-EX TI DRV8874 based motor shield
@@ -96,7 +96,7 @@ The configuration file for DCC-EX Command Station
 //#define DONT_TOUCH_WIFI_CONF
 //
 // WIFI_SSID is the network name IF you want to use your existing home network.
-// Do NOT change this if you want to use the WiFi in Access Point (AP) mode. 
+// Do NOT change this if you want to use the WiFi in Access Point (AP) mode.
 //
 // If you do NOT set the WIFI_SSID and do NOT set the WIFI_PASSWORD,
 // then the WiFi chip will first try to connect to the previously
@@ -112,14 +112,17 @@ The configuration file for DCC-EX Command Station
 //
 // WIFI_PASSWORD is the network password for your home network or if
 // you want to change the password from default AP mode password
-// to the AP password you want. 
+// to the AP password you want.
 // Your password may not contain ``"'' (double quote, ASCII 0x22).
 #define WIFI_PASSWORD "Your network passwd"
 //
 // WIFI_HOSTNAME: You probably don't need to change this
+// Note: If you're using OTA updates (OTA_ENABLED == true), and decide
+// to modify this name, remember to concurrently update the "upload_port"
+// in the corresponding environment within the platformio.ini file.
 #define WIFI_HOSTNAME "dccex"
 //
-// WIFI_CHANNEL: If the line "#define ENABLE_WIFI true" is uncommented, 
+// WIFI_CHANNEL: If the line "#define ENABLE_WIFI true" is uncommented,
 // WiFi will be enabled (Mega only). The default channel is set to "1" whether
 // this line exists or not. If you need to use an alternate channel (we recommend
 // using only 1,6, or 11) you may change it here.
@@ -129,6 +132,17 @@ The configuration file for DCC-EX Command Station
 // true. Otherwise it is assumed that you'd like to connect to an existing network
 // with that SSID.
 #define WIFI_FORCE_AP false
+//
+// OTA_ENABLED: If you'd like to enable OTA updates, set this to true. Otherwise,
+// OTA updates will not be available.
+#define OTA_ENABLED true
+//
+// OTA_AUTH: If you'd like to change the OTA password, set this to the password
+// you'd like to use. Otherwise, the default password will be "dccex-ota".
+// Note: After changing the OTA password, you must update the "upload_flags → --auth"
+// in the corresponding environment within the platformio.ini file.
+#define OTA_AUTH "dccex-ota"
+
 
 /////////////////////////////////////////////////////////////////////////////////////
 //
@@ -186,7 +200,7 @@ The configuration file for DCC-EX Command Station
 // If you do not need programming capability, you can disable all programming related
 // commands. You might want to do that if you are using an Arduino UNO and still want
 // to use EXRAIL automation, as the Uno is lacking in RAM and Flash to run both.
-// 
+//
 // Note this disables all programming functionality, including EXRAIL.
 //
 // #define DISABLE_PROG
@@ -195,9 +209,9 @@ The configuration file for DCC-EX Command Station
 // REDEFINE WHERE SHORT/LONG ADDR break is. According to NMRA the last short address
 // is 127 and the first long address is 128. There are manufacturers which have
 // another view. Lenz CS for example have considered addresses long from 100. If
-// you want to change to that mode, do 
+// you want to change to that mode, do
 //#define HIGHEST_SHORT_ADDR 99
-// If you want to run all your locos addressed long format, you could even do a 
+// If you want to run all your locos addressed long format, you could even do a
 //#define HIGHEST_SHORT_ADDR 0
 // We do not support to use the same address, for example 100(long) and 100(short)
 // at the same time, there must be a border.
@@ -208,7 +222,7 @@ The configuration file for DCC-EX Command Station
 //
 // According to norm RCN-213 a DCC packet with a 1 is closed/straight
 // and one with a 0 is thrown/diverging.  In DCC++ Classic, and in previous
-// versions of DCC++EX, a turnout throw command was implemented in the packet as 
+// versions of DCC++EX, a turnout throw command was implemented in the packet as
 // '1' and a close command as '0'. The #define below makes the states
 // match with the norm.  But we don't want to cause havoc on existent layouts,
 // so we define this only for new installations. If you don't want this,
@@ -227,7 +241,7 @@ The configuration file for DCC-EX Command Station
 // you can use this to reverse the sense of all accessory commmands sent
 // over DCC++. This #define likewise inverts the behaviour of the <a> command
 // for triggering DCC Accessory Decoders, so that <a addr subaddr 0> generates a
-// DCC packet with D=1 (close turnout) and <a addr subaddr 1> generates D=0 
+// DCC packet with D=1 (close turnout) and <a addr subaddr 1> generates D=0
 // (throw turnout).
 //#define DCC_ACCESSORY_RCN_213
 //

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = 
+default_envs =
 	mega2560
 	uno
 	mega328
@@ -66,7 +66,7 @@ build_flags = -std=c++17 ; -DI2C_USE_WIRE  -DDIAG_LOOPTIMES -DDIAG_IO
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
@@ -78,19 +78,19 @@ build_flags =  -DDIAG_IO=2 -DDIAG_LOOPTIMES
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
 monitor_speed = 115200
 monitor_echo = yes
-build_flags = -DIO_NO_HAL 
+build_flags = -DIO_NO_HAL
 
 [env:mega2560-I2C-wire]
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
@@ -102,7 +102,7 @@ build_flags = -DI2C_USE_WIRE
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
@@ -114,7 +114,7 @@ build_flags =     ; -DDIAG_LOOPTIMES
 platform = atmelavr
 board = uno
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
@@ -125,7 +125,7 @@ monitor_echo = yes
 platform = atmelmegaavr
 board = uno_wifi_rev2
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
@@ -137,20 +137,20 @@ build_flags = "-DF_CPU=16000000L -DARDUINO=10813 -DARDUINO_AVR_UNO_WIFI_DEV_ED -
 platform = atmelmegaavr
 board = nano_every
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
 monitor_speed = 115200
 monitor_echo = yes
 upload_speed = 19200
-build_flags = 
+build_flags =
 
 [env:uno]
 platform = atmelavr
 board = uno
 framework = arduino
-lib_deps = 
+lib_deps =
 	${env.lib_deps}
 	arduino-libraries/Ethernet
 	SPI
@@ -176,6 +176,19 @@ build_flags = -std=c++17
 monitor_speed = 115200
 monitor_echo = yes
 
+[env:ESP32-OTA]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps = ${env.lib_deps}
+build_flags = -std=c++17
+monitor_speed = 115200
+monitor_echo = yes
+upload_protocol = espota
+upload_port = dccex
+upload_flags =
+	--auth=dccex-ota
+
 [env:Nucleo-F411RE]
 platform = ststm32
 board = nucleo_f411re
@@ -190,7 +203,7 @@ platform = ststm32
 board = nucleo_f446re
 framework = arduino
 lib_deps = ${env.lib_deps}
-build_flags = -std=c++17  -Os -g2 -Wunused-variable ; -DDIAG_LOOPTIMES ; -DDIAG_IO 
+build_flags = -std=c++17  -Os -g2 -Wunused-variable ; -DDIAG_LOOPTIMES ; -DDIAG_IO
 monitor_speed = 115200
 monitor_echo = yes
 
@@ -232,5 +245,5 @@ board = teensy41
 framework = arduino
 build_flags = -std=c++17  -Os -g2
 lib_deps = ${env.lib_deps}
-lib_ignore = 
+lib_ignore =
 


### PR DESCRIPTION
This pull request introduces support for ArduinoOTA updates on ESP32-based boards. This feature allows for wireless updating of the firmware over the network, which significantly simplifies the update process for devices that are not easily accessible.

Changes include:

- Added necessary ArduinoOTA library includes and setup calls in the appropriate conditional compilation sections.
- Integrated ArduinoOTA handlers into the main loop to listen for incoming update requests.
- Configured OTA settings such as hostname and password for secure firmware updates.
- Updated platformio.ini configuration to support OTA updates.

This enhancement provides a robust and user-friendly method for firmware updates, reducing the need for physical access to the device and streamlining the update process. 

Please review and provide any feedback.