### PR TITLE
Added broadcast for (extended) accessory commands

### DIFF
--- a/CommandDistributor.cpp
+++ b/CommandDistributor.cpp
@@ -152,6 +152,14 @@ void  CommandDistributor::broadcastSensor(int16_t id, bool on ) {
   broadcastReply(COMMAND_TYPE, F("<%c %d>\n"), on?'Q':'q', id);
 }
 
+void CommandDistributor::broadcastAccessory(int16_t address, byte port, bool gate, bool on) {
+  broadcastReply(COMMAND_TYPE, F("<y a %d %d %c %c>\n"), address, port, gate?'1':'0', on?'1':'0');
+}
+
+void CommandDistributor::broadcastExtendedAccessory(int16_t address, int16_t value) {
+  broadcastReply(COMMAND_TYPE, F("<y A %d %d>\n"), address, value);
+}
+
 void  CommandDistributor::broadcastTurnout(int16_t id, bool isClosed ) {
   // For DCC++ classic compatibility, state reported to JMRI is 1 for thrown and 0 for closed;
   // The string below contains serial and Withrottle protocols which should

--- a/CommandDistributor.h
+++ b/CommandDistributor.h
@@ -49,6 +49,8 @@ public :
   static void broadcastLoco(byte slot);
   static void broadcastForgetLoco(int16_t loco);
   static void broadcastSensor(int16_t id, bool value);
+  static void broadcastAccessory(int16_t address, byte port, bool gate, bool on);
+  static void broadcastExtendedAccessory(int16_t address, int16_t value);
   static void broadcastTurnout(int16_t id, bool isClosed);
   static void broadcastTurntable(int16_t id, uint8_t position, bool moving);
   static void broadcastClockTime(int16_t time, int8_t rate);

--- a/DCC.cpp
+++ b/DCC.cpp
@@ -307,10 +307,12 @@ void DCC::setAccessory(int address, byte port, bool gate, byte onoff /*= 2*/) {
 #if defined(EXRAIL_ACTIVE)
     RMFT2::activateEvent(address<<2|port,gate);
 #endif
+    CommandDistributor::broadcastAccessory(address, port, gate, true);
   }
   if (onoff != 1) {
     b[1] &= ~0x08; // set C to 0
     DCCWaveform::mainTrack.schedulePacket(b, 2, 3);      // Repeat off packet three times
+    CommandDistributor::broadcastAccessory(address, port, gate, false);
   }
 }
 
@@ -362,6 +364,7 @@ whole range of the 11 bits sent to track.
     | ((address & 0x03)<<1);         // mask 2 bits, shift up 1
   b[2]=value;
   DCCWaveform::mainTrack.schedulePacket(b, sizeof(b), repeats);
+  CommandDistributor::broadcastExtendedAccessory(address, value);
   return true;
 }
 

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -92,7 +92,7 @@ Once a new OPCODE is decided upon, update this list.
   W, Write CV
   x,
   X, Invalid command response
-  y, 
+  y, Accessory/extended accessory broadcast
   Y, Output broadcast
   z, Direct output
   Z, Output configuration/control


### PR DESCRIPTION
This PR adds broadcast commands `<y a ...>` for accessory and `<y A ...>` for extended accessory. Similar to the `<l ...>` command for engines/locomotives.

Without these broadcasts it is impossible to track these accessory command when multiple clients are involved.

Closes #444