### PR TITLE
Add PrettyOTA for ESP32

### DIFF
--- a/ESPPrettyOTA.cpp
+++ b/ESPPrettyOTA.cpp
@@ -1,0 +1,125 @@
+
+/*
+ *  © 2025 Mathew Winters
+ *  All rights reserved.
+ *
+ *  This file is part of CommandStation-EX
+ *
+ *  This is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  It is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifdef ARDUINO_ARCH_ESP32
+#include "ESPPrettyOTA.h"
+
+#include "DCC.h"
+#include "DIAG.h"
+#include "config.h"
+#include "version.h"
+
+#ifndef OTA_USERNAME
+#define OTA_USERNAME ""
+#endif
+#ifndef OTA_PASSWORD
+#define OTA_PASSWORD ""
+#endif
+#ifndef OTA_PASSWORD_IS_MD5_HASH
+#define OTA_PASSWORD_IS_MD5_HASH false
+#endif
+
+// Custom stream to wrap output from PrettyOTA to DIAG
+class CustomDiagStream : public Stream {
+ public:
+  CustomDiagStream() {}
+
+  size_t write(uint8_t c) override {
+    if (!_started) {
+      _started = true;
+    }
+
+    if (c == '\n' || c == '\r') {
+      _started = false;
+      DIAG(buildOutput.c_str());
+      buildOutput = "";
+    } else {
+      buildOutput += (char)c;
+    }
+    return 1;
+  }
+
+  int available() override { return 0; }
+
+  int read() override { return 0; }
+
+  int peek() override { return 0; }
+
+  void flush() override {}
+
+ private:
+  bool _started = false;
+  String buildOutput;
+};
+
+void ESPPrettyOTA::setup() {
+  // Print IP address
+  DIAG(F("PrettyOTA can be accessed at: http://%s/update"),
+       WiFi.localIP().toString().c_str());
+
+  // Initialize PrettyOTA
+  OTAUpdates.SetSerialOutputStream(new CustomDiagStream());
+  OTAUpdates.Begin(&webServer);
+
+  if (OTA_USERNAME != "" && OTA_PASSWORD != "") {
+    OTAUpdates.SetAuthenticationDetails(OTA_USERNAME, OTA_PASSWORD, OTA_PASSWORD_IS_MD5_HASH);
+  }
+
+  // Set firmware version to VERSION
+  OTAUpdates.OverwriteAppVersion(VERSION);
+
+  // Set current build time and date
+  PRETTY_OTA_SET_CURRENT_BUILD_TIME_AND_DATE();
+
+  // set custom callbacks
+  OTAUpdates.OnStart([this](NSPrettyOTA::UPDATE_MODE updateMode) {
+    this->OnOTAStart(updateMode);
+  });
+  OTAUpdates.OnProgress([this](uint32_t currentSize, uint32_t totalSize) {
+    this->OnOTAProgress(currentSize, totalSize);
+  });
+
+  // Start web server
+  webServer.begin();
+}
+
+// we wrap the default output to be compatible with
+// the DIAG output and print much less.
+void ESPPrettyOTA::OnOTAStart(NSPrettyOTA::UPDATE_MODE updateMode) {
+  DIAG(F("OTA update started - stopping DCC-EX"));
+  DCC::setThrottle(0, 1, 1);  // taken from ! Stop
+}
+
+// Gets called while update is running
+// currentSize: Number of bytes already processed
+// totalSize: Total size of new firmware in bytes
+void ESPPrettyOTA::OnOTAProgress(uint32_t currentSize, uint32_t totalSize) {
+  static float lastPercentage = 0.0f;
+  const float percentage = 100.0f * static_cast<float>(currentSize) / static_cast<float>(totalSize);
+  const uint8_t numBarsToShow = static_cast<uint8_t>(percentage / 3.3333f);
+
+  if (percentage - lastPercentage >= 1.0f) {
+    DIAG(F("OTA Progress: %02u%%"), static_cast<uint8_t>(percentage));
+    lastPercentage = percentage;
+  }
+}
+
+#endif

--- a/ESPPrettyOTA.h
+++ b/ESPPrettyOTA.h
@@ -1,0 +1,45 @@
+
+/*
+ *  © 2025 Mathew Winters
+ *  All rights reserved.
+ *
+ *  This file is part of CommandStation-EX
+ *
+ *  This is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  It is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef PrettyOTA_h
+#define PrettyOTA_h
+
+// installs PrettyOTA https://github.com/LostInCompilation/PrettyOTA
+
+#ifdef ARDUINO_ARCH_ESP32
+#include <PrettyOTA.h>
+
+class ESPPrettyOTA {
+ private:
+  PrettyOTA OTAUpdates;
+  AsyncWebServer webServer;
+
+ public:
+  ESPPrettyOTA() : webServer(80) {}
+  void setup();
+
+  void OnOTAStart(NSPrettyOTA::UPDATE_MODE updateMode);
+  void OnOTAProgress(uint32_t currentSize, uint32_t totalSize);
+  void OnOTAEnd(bool successful);
+};
+
+#endif
+#endif

--- a/WifiESP32.cpp
+++ b/WifiESP32.cpp
@@ -33,6 +33,8 @@
 #include "WiThrottle.h"
 #include "DCC.h"
 #include "Websockets.h"
+#include "ESPPrettyOTA.h"
+
 /*
 #include "soc/rtc_wdt.h"
 #include "esp_task_wdt.h"
@@ -119,6 +121,7 @@ static bool APmode = false;
 // init of static class scope variables
 bool WifiESP::wifiUp = false;
 WiFiServer *WifiESP::server = NULL;
+ESPPrettyOTA OTAUpdates;
 
 #ifdef WIFI_TASK_ON_CORE0
 void wifiLoop(void *){
@@ -304,6 +307,9 @@ bool WifiESP::setup(const char *SSid,
   server = new WiFiServer(port); // start listening on tcp port
   server->begin();
   // server started here
+
+  // start OTA
+  OTAUpdates.setup();
 
 #ifdef WIFI_TASK_ON_CORE0
   //start loop task

--- a/config.example.h
+++ b/config.example.h
@@ -360,3 +360,15 @@ The configuration file for DCC-EX Command Station
 // That is described further above.
 //
 /////////////////////////////////////////////////////////////////////////////////////
+
+
+// PrettyOTA Settings for ESP32.
+// See https://github.com/LostInCompilation/PrettyOTA
+// you can md5 the password
+// example:
+// $ echo -n "password"| md5sum -t 
+// 5f4dcc3b5aa765d61d8327deb882cf99  -
+//
+// #define OTA_USERNAME ""
+// #define OTA_PASSWORD ""
+// #define OTA_PASSWORD_IS_MD5_HASH false

--- a/platformio.ini
+++ b/platformio.ini
@@ -187,9 +187,29 @@ platform = espressif32 @ 6.7.0
 board = esp32dev
 framework = arduino
 lib_deps = ${env.lib_deps}
+	lostincompilation/PrettyOTA @ ^1.1.2
+lib_compat_mode = strict	
 build_flags = -std=c++17
 monitor_speed = 115200
 monitor_echo = yes
+
+[env:ESP32_OTA]
+; Lock version to 6.7.0 as that is
+; Arduino v2.0.16 (based on IDF v4.4.7)
+; which is the latest version based
+; on IDF v4. We can not use IDF v5.
+platform = espressif32 @ 6.7.0
+board = esp32dev
+framework = arduino
+lib_deps = ${env.lib_deps}
+	lostincompilation/PrettyOTA @ ^1.1.2
+lib_compat_mode = strict
+build_flags = -std=c++17
+monitor_speed = 115200
+monitor_echo = yes
+upload_protocol = espota
+upload_port = 192.168.x.x
+
 
 [env:Nucleo-F411RE]
 platform = ststm32 @ 19.0.0


### PR DESCRIPTION
Add PrettyOTA for ESP32, so that the devices can have firmware uploaded over the wifi.
This uses a http interface, or the arduino ota interface.

The info stream has had itself wrapped in a stream to properly log to DIAG.

https://github.com/LostInCompilation/PrettyOTA

Updated the library, and added proper logging for any outputs PrettyOTA has. 
The wrapper over start and progress is so that the default output
will be hidden away.
