### PR TITLE
NucleoTimerSync for DC mode tracks

### DIFF
--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -1,6 +1,7 @@
 /*
  *  © 2023 Neil McKechnie
  *  © 2022-2024 Paul M. Antoine
+ *  © 2025 Herb Morton
  *  © 2021 Mike S
  *  © 2021, 2023 Harald Barth
  *  © 2021 Fred Decker
@@ -35,6 +36,21 @@
 #endif
 #include "DIAG.h"
 #include <wiring_private.h>
+
+// DC mode timers enable the PWM signal on select pins.
+// Code added to sync timers which have the same frequency.
+// Function prototypes
+void refreshDCmodeTimers();
+void resetCounterDCmodeTimers();
+
+HardwareTimer *Timer1 = new HardwareTimer(TIM1);
+HardwareTimer *Timer2 = new HardwareTimer(TIM2);
+HardwareTimer *Timer3 = new HardwareTimer(TIM3);
+HardwareTimer *Timer4 = new HardwareTimer(TIM4);
+HardwareTimer *Timer9 = new HardwareTimer(TIM9);
+#if defined(TIM13)
+HardwareTimer *Timer13 = new HardwareTimer(TIM13);
+#endif
 
 #if defined(ARDUINO_NUCLEO_F401RE)
 // Nucleo-64 boards don't have additional serial ports defined by default
@@ -290,7 +306,7 @@ void DCCTimer::DCCEXanalogWriteFrequency(uint8_t pin, uint32_t f) {
   else if (f >= 3)
     DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 16000);
   else if (f >= 2)
-    DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 3400);
+    DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 3600);
   else if (f == 1)
     DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 480);
   else
@@ -328,7 +344,8 @@ void DCCTimer::DCCEXanalogWriteFrequencyInternal(uint8_t pin, uint32_t frequency
     if (pin_timer[pin] != NULL)
     {
       pin_timer[pin]->setPWM(pin_channel[pin], pin, frequency, 0); // set frequency in Hertz, 0% dutycycle
-      DIAG(F("DCCEXanalogWriteFrequency::Pin %d on Timer Channel %d, frequency %d"), pin, pin_channel[pin], frequency);
+      DIAG(F("DCCEXanalogWriteFrequency::Pin %d on Timer %d Channel %d, frequency %d"), pin, pin_timer[pin], pin_channel[pin], frequency);
+      resetCounterDCmodeTimers();
     }
     else
       DIAG(F("DCCEXanalogWriteFrequency::failed to allocate HardwareTimer instance!"));
@@ -341,6 +358,7 @@ void DCCTimer::DCCEXanalogWriteFrequencyInternal(uint8_t pin, uint32_t frequency
       pinmap_pinout(digitalPinToPinName(pin), PinMap_TIM); // ensure the pin has been configured!
       pin_timer[pin]->setOverflow(frequency, HERTZ_FORMAT); // Just change the frequency if it's already running!
       DIAG(F("DCCEXanalogWriteFrequency::setting frequency to %d"), frequency);
+      resetCounterDCmodeTimers();
     }
   }
   channel_frequency[pin] = frequency;
@@ -365,6 +383,8 @@ void DCCTimer::DCCEXanalogWrite(uint8_t pin, int value, bool invert) {
         pin_timer[pin]->setCaptureCompare(pin_channel[pin], duty_cycle, PERCENT_COMPARE_FORMAT); // DCC_EX_PWM_FREQ Hertz, duty_cycle% dutycycle
         DIAG(F("DCCEXanalogWrite::Pin %d, value %d, duty cycle %d"), pin, value, duty_cycle);
       // }
+      refreshDCmodeTimers();
+      resetCounterDCmodeTimers();
     }
     else
       DIAG(F("DCCEXanalogWrite::Pin %d is not configured for PWM!"), pin);
@@ -659,4 +679,35 @@ void ADCee::begin() {
 #endif
   interrupts();
 }
+
+// NOTE:  additional testing is needed to check the DCC signal 
+//        where the DCC signal pin is a pwm pin on timers 1, 2, 3, 4, 9, 13
+//        or the brake pin is defined on a different timer.
+//        -- example:  F411RE/F446RE - pin 10 on stacked EX8874  
+// lines added to sync timers -- 
+//    not exact sync, but timers with the same frequency should be in sync
+void refreshDCmodeTimers() {
+  Timer1->refresh();
+  Timer2->refresh();
+  Timer3->refresh();
+  Timer4->refresh();
+  Timer9->refresh();
+  #if defined(TIM13)
+  Timer13->refresh();
+  #endif
+}
+
+// Function to synchronize timers - called every time there is powerON commmand for any DC track
+void resetCounterDCmodeTimers() {
+    // Reset the counter for all DC mode timers
+    TIM1->CNT = 0;
+    TIM2->CNT = 0;
+    TIM3->CNT = 0;
+    TIM4->CNT = 0;
+    TIM9->CNT = 0;
+    #if defined(TIM13)
+    TIM13->CNT = 0;
+    #endif
+}
+
 #endif

--- a/MotorDriver.cpp
+++ b/MotorDriver.cpp
@@ -1,6 +1,6 @@
 /*
  *  © 2022-2024 Paul M Antoine
- *  © 2024 Herb Morton
+ *  © 2024-2025 Herb Morton
  *  © 2021 Mike S
  *  © 2021 Fred Decker
  *  © 2020-2023 Harald Barth
@@ -371,8 +371,8 @@ void MotorDriver::setDCSignal(byte speedcode, uint8_t frequency /*default =0*/) 
     }
 #endif
     //DIAG(F("Brake pin %d value %d freqency %d"), brakePin, brake, f);
-    DCCTimer::DCCEXanalogWrite(brakePin, brake, invertBrake);
     DCCTimer::DCCEXanalogWriteFrequency(brakePin, f); // set DC PWM frequency
+    DCCTimer::DCCEXanalogWrite(brakePin, brake, invertBrake);  // line swapped to set frequency first
 #else // all AVR here
     DCCTimer::DCCEXanalogWriteFrequency(brakePin, frequency); // frequency steps
     analogWrite(brakePin, invertBrake ? 255-brake : brake);

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -1,6 +1,7 @@
 /*
  *  © 2022 Chris Harlow
  *  © 2022-2024 Harald Barth
+ *  © 2025 Herb Morton
  *  © 2023 Colin Murdoch
  * 
  *  All rights reserved.
@@ -69,6 +70,7 @@ class TrackManager {
     static void setTrackPower(TRACK_MODE trackmode, POWERMODE powermode);
     static void setMainPower(POWERMODE mode) {setTrackPower(TRACK_MODE_MAIN, mode);}
     static void setProgPower(POWERMODE mode) {setTrackPower(TRACK_MODE_PROG, mode);}
+    static void setTrackPowerF439ZI(byte t);
 
     static const int16_t MAX_TRACKS=8;
     static bool setTrackMode(byte track, TRACK_MODE mode, int16_t DCaddr=0);

--- a/version.h
+++ b/version.h
@@ -4,6 +4,7 @@
 #include "StringFormatter.h"
 
 #define VERSION "5.5.23"
+// 5.5.24 - Sync DC mode tracks - Nucleo-F4
 // 5.5.23 - Reminder loop Idle packet optimization
 // 5.5.22 - (5.4.9) Handle non-compliant decoders returning 255 for cv 20 and confusing <R> with bad consist addresses.
 //        - DCC 5mS gap to same loco DCC packet restriction


### PR DESCRIPTION
The effect of these changes will result in sync of DC mode tracks (for Nucleo-F4) to permit driving between districts. 

The version number will need to be updated.  The comment line was added, but version is unchanged -- and so that the branches can be automatically merged. 