### PR TITLE
Add Railcom cutout to STM32 platform

### DIFF
--- a/DCCTimer.h
+++ b/DCCTimer.h
@@ -62,7 +62,7 @@ class DCCTimer {
   static bool isPWMPin(byte pin);
   static void setPWM(byte pin, bool high);
   static void clearPWM();
-  static void startRailcomTimer(byte brakePin);
+  static void startRailcomTimer();
   static void ackRailcomTimer();
   static void DCCEXanalogWriteFrequency(uint8_t pin, uint32_t frequency);
   static void DCCEXanalogWrite(uint8_t pin, int value, bool invert);

--- a/DCCTimerAVR.cpp
+++ b/DCCTimerAVR.cpp
@@ -61,8 +61,7 @@ void DCCTimer::begin(INTERRUPT_CALLBACK callback) {
   }
 
 
-void DCCTimer::startRailcomTimer(byte brakePin) {
-  (void) brakePin; // Ignored... works on pin 9 only 
+void DCCTimer::startRailcomTimer() {
   // diagnostic digitalWrite(4,HIGH);   
 
   /* The Railcom timer is started in such a way that it 

--- a/DCCTimerMEGAAVR.cpp
+++ b/DCCTimerMEGAAVR.cpp
@@ -80,9 +80,8 @@ extern char *__malloc_heap_start;
     interruptHandler();
   }
 
-void DCCTimer::startRailcomTimer(byte brakePin) {
+void DCCTimer::startRailcomTimer() {
   // TODO: for intended operation see DCCTimerAVR.cpp
-  (void) brakePin; 
 }
 
 void DCCTimer::ackRailcomTimer() {

--- a/DCCTimerSAMD.cpp
+++ b/DCCTimerSAMD.cpp
@@ -76,9 +76,8 @@ void DCCTimer::begin(INTERRUPT_CALLBACK callback) {
   interrupts();
 }
 
-void DCCTimer::startRailcomTimer(byte brakePin) {
+void DCCTimer::startRailcomTimer() {
   // TODO: for intended operation see DCCTimerAVR.cpp
-  (void) brakePin; 
 }
 
 void DCCTimer::ackRailcomTimer() {

--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -216,12 +216,11 @@ void DCCTimer::begin(INTERRUPT_CALLBACK callback) {
 static HardwareTimer *railcomTimer = nullptr;
 
 void DCCTimer::startRailcomTimer() {
-  // Initialize main timer if not already done
   if (!railcomTimer) {
     railcomTimer = new HardwareTimer(TIM3);
   }
 
-  // Start the timer to begin the cutout in ~29us
+  // Start the timer to begin the cutout in ~29+58us
   railcomTimer->resume();
 }
 

--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -233,8 +233,6 @@ void startRailcomCallback() {
 }
 
 void DCCTimer::ackRailcomTimer() {
-  uint32_t cutoutOffset;
-
   // Un-set the track brake
   TrackManager::setMainBrake(false, true);
 
@@ -243,17 +241,13 @@ void DCCTimer::ackRailcomTimer() {
   // the start of the preamble so we can do time-consuming timer configuration
   // without disrupting the DCC signal.
   if (railcomTimer) {
-    railcomTimer->setPrescaleFactor(1);
-
-    // Sync up with the primary DCC timer.
-    cutoutOffset = dcctimer.getOverflow(MICROSEC_FORMAT) + 26;
-    railcomTimer->setOverflow(cutoutOffset, MICROSEC_FORMAT);
-    railcomTimer->setCount(dcctimer.getCount());
-
     // Arm the timer for the next cutout
+    railcomTimer->pause();
+    railcomTimer->setPrescaleFactor(1);
+    railcomTimer->setOverflow(58+26, MICROSEC_FORMAT);
+    railcomTimer->setCount(0);
     railcomTimer->refresh();
     railcomTimer->attachInterrupt(startRailcomCallback);
-    railcomTimer->pause();
   }
 }
 

--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -232,15 +232,14 @@ void startRailcomCallback() {
 }
 
 void DCCTimer::ackRailcomTimer() {
+  // Immediately end the Railcom cutout and set up the timer for the next
+  // cutout. Setting up the timer here avoids distorting the packet end bit
+  // with delayed interrupts.
+
   // Un-set the track brake
   TrackManager::setMainBrake(false, true);
 
-  // Immediately end the Railcom cutout and set up the timer for the next
-  // cutout. We're in the no-man's land between the end of the cutout window and
-  // the start of the preamble so we can do time-consuming timer configuration
-  // without disrupting the DCC signal.
   if (railcomTimer) {
-    // Arm the timer for the next cutout
     railcomTimer->pause();
     railcomTimer->setPrescaleFactor(1);
     railcomTimer->setOverflow(58+26, MICROSEC_FORMAT);

--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -217,7 +217,7 @@ static HardwareTimer *railcomTimer = nullptr;
 
 void DCCTimer::startRailcomTimer() {
   if (!railcomTimer) {
-    railcomTimer = new HardwareTimer(TIM3);
+    railcomTimer = new HardwareTimer(TIM5);
   }
 
   // Start the timer to begin the cutout in ~29+58us

--- a/DCCTimerTEENSY.cpp
+++ b/DCCTimerTEENSY.cpp
@@ -39,9 +39,8 @@ void DCCTimer::begin(INTERRUPT_CALLBACK callback) {
   myDCCTimer.begin(interruptHandler, DCC_SIGNAL_TIME);
   }
 
-void DCCTimer::startRailcomTimer(byte brakePin) {
+void DCCTimer::startRailcomTimer() {
   // TODO: for intended operation see DCCTimerAVR.cpp
-  (void) brakePin; 
 }
 
 void DCCTimer::ackRailcomTimer() {

--- a/DCCWaveform.cpp
+++ b/DCCWaveform.cpp
@@ -79,7 +79,7 @@ void DCCWaveform::interruptHandler() {
     cutoutNextTime=false;
     railcomSampleWindow=false; // about to cutout, stop reading railcom data.
     railcomCutoutCounter++;
-    DCCTimer::startRailcomTimer(9);
+    DCCTimer::startRailcomTimer();
   }
   #endif
   byte sigMain=signalTransform[mainTrack.state];
@@ -177,7 +177,7 @@ void DCCWaveform::interrupt2() {
         railcomLastAddressHigh=transmitPacket[0];
         railcomLastAddressLow =transmitPacket[1];
         railcomSampleWindow=true;
-      } else if (remainingPreambles==(requiredPreambles-3)) {
+      } else if (remainingPreambles==(requiredPreambles-6)) {
         // cutout can be ended when read
         // see above for requiredPreambles
         DCCTimer::ackRailcomTimer();

--- a/DCCWaveform.h
+++ b/DCCWaveform.h
@@ -30,7 +30,7 @@
 
 
 // Number of preamble bits.
-const byte PREAMBLE_BITS_MAIN = 16;
+const byte PREAMBLE_BITS_MAIN = 18;
 const byte PREAMBLE_BITS_PROG = 22;
 const byte MAX_PACKET_SIZE = 5;     // NMRA standard extended packets, payload size WITHOUT checksum.
 

--- a/DCCWaveform.h
+++ b/DCCWaveform.h
@@ -30,7 +30,7 @@
 
 
 // Number of preamble bits.
-const byte PREAMBLE_BITS_MAIN = 18;
+const byte PREAMBLE_BITS_MAIN = 16;
 const byte PREAMBLE_BITS_PROG = 22;
 const byte MAX_PACKET_SIZE = 5;     // NMRA standard extended packets, payload size WITHOUT checksum.
 

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -344,7 +344,7 @@ bool TrackManager::setTrackMode(byte trackToSet, TRACK_MODE mode, int16_t dcAddr
       DCCTimer::clearPWM(); // has to be AFTER trackPWM changes because if trackPWM==true this is undone for  that track
     }
 #ifdef ARDUINO_ARCH_STM32
-    // High accuracy mode is not yet implemented or really needed to do Railcom on STM32
+    // High accuracy mode is not needed for Railcom on STM32
     DCCWaveform::setRailcomPossible(true);
 #else
     DCCWaveform::setRailcomPossible(canDo);

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -71,6 +71,10 @@ class TrackManager {
     static void setMainPower(POWERMODE mode) {setTrackPower(TRACK_MODE_MAIN, mode);}
     static void setProgPower(POWERMODE mode) {setTrackPower(TRACK_MODE_PROG, mode);}
 
+    static void setTrackBrake(TRACK_MODE trackmode, bool on, bool interruptContext=false);
+    static void setMainBrake(bool on, bool interruptContext=false);
+    static void setProgBrake(bool on, bool interruptContext=false) {setTrackBrake(TRACK_MODE_PROG, on, interruptContext);}
+
     static const int16_t MAX_TRACKS=8;
     static bool setTrackMode(byte track, TRACK_MODE mode, int16_t DCaddr=0, bool offAtChange=true);
     static bool parseEqualSign(Print * stream,  int16_t params, int16_t p[]);


### PR DESCRIPTION
Hey, I was looking at adding some Railcom-based block detection to my layout and I saw STM32 didn't have support for the cutout yet. I don't have other NUCLEO boards to test with, but here's the results from my NUCLEO-F446RE on my scope. Overall cutout window clocks in at 468us, right about in the middle of the spec (min/max: 454/488) and same for the initial delay, 30us (spec min/max: 26/32)

![stm32-full-railcom-cutout](https://github.com/user-attachments/assets/339036a0-60ee-4abc-927c-52ee47c7d8ff)
![stm32-initial-railcom-cutout](https://github.com/user-attachments/assets/93fd22d4-3152-44c9-9db5-ca37aeb96ee1)