### PR TITLE
hotfix for station mode DHCP

### DIFF
--- a/WifiInterface.cpp
+++ b/WifiInterface.cpp
@@ -235,6 +235,10 @@ wifiSerialState WifiInterface::setup2(const FSH* SSid, const FSH* password,
   StringFormatter::send(wifiStream, F("AT+CWMODE%s=1\r\n"), oldCmd ? "" : "_CUR"); // configure as "station" = WiFi client
   checkForOK(1000, true);                       // Not always OK, sometimes "no change"
 
+  // sometimes the esp8266 will get stuck with DHCP off, so reset DHCP to on
+  StringFormatter::send(wifiStream, F("AT+CWDHCP%s=1,1\r\n"), oldCmd ? "" : "_CUR");
+  checkForOK(1000, true);
+
   const char *yourNetwork = "Your network ";
   if (STRNCMP_P(yourNetwork, (const char*)SSid, 13) == 0 || STRNCMP_P("", (const char*)SSid, 13) == 0) {
     if (STRNCMP_P(yourNetwork, (const char*)password, 13) == 0) {


### PR DESCRIPTION
This is an impromptu fix for station mode DHCP.

## Context
In my personal layout I use a DCC-EX command station that is an esp8266, arduino mega, and the arduino motor driver with the HW tweaks applied to it.

## Problem
To that extent I had an issues that (I forgot about because I kludged it at home). When working with The command station on an existing network, the WifiInterface does not enforce DHCP being on. This leads to whatever the manufacturer default OR whatever was falshed to the network chip acting as the default.

## Solution
This simple 3 line remedy just uses the AT command support already in the project to force interface 1 into DHCP mode before creating a connection.