### PR TITLE
Update IO_PCA9685.cpp

### DIFF
--- a/IO_PCA9685.cpp
+++ b/IO_PCA9685.cpp
@@ -34,7 +34,7 @@ static const float FREQUENCY_OSCILLATOR=25000000.0; /** Accurate enough for our 
 static const uint32_t MAX_I2C_SPEED = 1000000L; // PCA9685 rated up to 1MHz I2C clock speed
 
 // Predeclare helper function
-static void writeRegister(byte address, byte reg, byte value);
+static void writeRegister(I2CAddress address, byte reg, byte value);
 
 // Create device driver instance.
 void PCA9685::create(VPIN firstVpin, int nPins, I2CAddress i2cAddress, uint16_t frequency) {
@@ -267,7 +267,7 @@ void PCA9685::_display() {
 }
 
 // Internal helper function for this device
-static void writeRegister(byte address, byte reg, byte value) {
+static void writeRegister(I2CAddress address, byte reg, byte value) {
   I2CManager.write(address, 2, reg, value);
 }
 


### PR DESCRIPTION
In the writeregister() function, the I2CAddress type must be used instead of the byte type. The byte type is not sufficient to initialize the servo module when using more than one multiplexer; the servos will not work.  Actually, there is no reason to use the byte type in the writeRegister() function . This function is inside the begin() function , to which the I2CAddress type is passed. And the writeRegister() function in turn calls I2CManager.write() , where the I2CAddress type is again used . So the only place where the byte type is is in the writeRegister() function.