### PR TITLE
Add NTP fast clock for ESP32 (master refresh)

### DIFF
--- a/CommandStation-EX.ino
+++ b/CommandStation-EX.ino
@@ -52,6 +52,7 @@
 #ifdef ARDUINO_ARCH_ESP32
 #include "Sniffer.h"
 #include "DCCDecoder.h"
+#include "NtpClock.h"
 Sniffer *dccSniffer = NULL;
 bool DCCDecoder::active = false;
 #endif // ARDUINO_ARCH_ESP32
@@ -203,6 +204,12 @@ void loop()
 #endif //ARDUINO_ARCH_ESP32
 #if ETHERNET_ON
   EthernetInterface::loop();
+#endif
+
+  // Feed the fast clock from NTP before EX-RAIL looks at it, so an
+  // ONCLOCKTIME fires in the same iteration the minute changes.
+#if defined(ARDUINO_ARCH_ESP32) && defined(NTP_CLOCK)
+  NtpClock::loop();
 #endif
 
   RMFT::loop();  // ignored if no automation

--- a/NtpClock.cpp
+++ b/NtpClock.cpp
@@ -1,0 +1,94 @@
+/*
+ *  © 2026 Kristian Kalweit
+ *
+ *  This file is part of CommandStation-EX
+ *
+ *  This is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  It is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "NtpClock.h"
+
+#if defined(ARDUINO_ARCH_ESP32) && defined(NTP_CLOCK)
+
+#include <WiFi.h>
+#include <time.h>
+#include "CommandDistributor.h"
+#include "DIAG.h"
+
+#ifndef NTP_CLOCK_SERVER
+#define NTP_CLOCK_SERVER "pool.ntp.org"
+#endif
+
+// POSIX timezone string. The default is Central European Time including the
+// EU daylight saving rules, so the model clock follows the wall clock.
+#ifndef NTP_CLOCK_TZ
+#define NTP_CLOCK_TZ "CET-1CEST,M3.5.0,M10.5.0/3"
+#endif
+
+// How many model minutes pass per real minute. 1 = model time is wall time.
+#ifndef NTP_CLOCK_RATE
+#define NTP_CLOCK_RATE 1
+#endif
+
+// Unix time of 2023-11-14. time() returns a value near 0 until SNTP has
+// answered, so anything below this means "not synced yet".
+static const time_t PLAUSIBLE_TIME = 1700000000;
+
+bool NtpClock::configured = false;
+bool NtpClock::synced = false;
+unsigned long NtpClock::lastPoll = 0;
+
+void NtpClock::loop() {
+  // Only in station mode. In AP mode the CS is its own network and there is
+  // no route to an NTP server, so there is nothing to wait for.
+  if (WiFi.status() != WL_CONNECTED) return;
+
+  // Nothing here needs to be timely, once a second is plenty.
+  unsigned long now = millis();
+  if (now - lastPoll < 1000) return;
+  lastPoll = now;
+
+  if (!configured) {
+    // Starts the SNTP client, which then resyncs on its own in the
+    // background (hourly by default).
+    configTzTime(NTP_CLOCK_TZ, NTP_CLOCK_SERVER);
+    configured = true;
+    DIAG(F("NTP clock: asking %S for the time"), F(NTP_CLOCK_SERVER));
+    return;
+  }
+
+  time_t rawTime = time(nullptr);
+  if (rawTime < PLAUSIBLE_TIME) return; // SNTP has not answered yet
+
+  struct tm local;
+  if (!localtime_r(&rawTime, &local)) return;
+
+  // Derive the model time from the wall clock rather than counting ticks,
+  // so a resync or a missed loop cannot make the model clock drift.
+  uint32_t secondsToday = local.tm_hour * 3600UL
+                        + local.tm_min * 60UL
+                        + local.tm_sec;
+  int16_t modelMinutes = (secondsToday * (uint32_t)NTP_CLOCK_RATE / 60) % 1440;
+
+  if (!synced) {
+    synced = true;
+    DIAG(F("NTP clock: synced to %d:%d, rate %d"),
+         local.tm_hour, local.tm_min, (int)NTP_CLOCK_RATE);
+  }
+
+  // Ignores repeated values, so calling this every second costs nothing.
+  CommandDistributor::setClockTime(modelMinutes, (int8_t)NTP_CLOCK_RATE);
+}
+
+#endif // ARDUINO_ARCH_ESP32 && NTP_CLOCK

--- a/NtpClock.h
+++ b/NtpClock.h
@@ -1,0 +1,57 @@
+/*
+ *  © 2026 Kristian Kalweit
+ *
+ *  This file is part of CommandStation-EX
+ *
+ *  This is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  It is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Feeds the DCC-EX fast clock from the ESP32 system clock, which is kept
+ * accurate by SNTP over the existing WiFi connection.
+ *
+ * The ESP32 has an RTC peripheral, but without a backup battery and without
+ * an external 32kHz crystal it drifts and is lost on every power cycle. NTP
+ * fixes that: the time is fetched once the WiFi is up and then resynced
+ * automatically by the SNTP client in the background.
+ *
+ * There is no setup() - the WiFi is not up when the sketch starts, so
+ * configuration happens lazily on the first loop() calls that see a
+ * connection. Enable with NTP_CLOCK in config.h, see config.example.h.
+ */
+
+#ifndef NtpClock_h
+#define NtpClock_h
+
+#include "defines.h"
+
+#if defined(ARDUINO_ARCH_ESP32) && defined(NTP_CLOCK)
+
+class NtpClock {
+public:
+  static void loop();
+
+  // True once a valid time has been received from NTP. Until then the model
+  // clock reads 0 (midnight) and must not be trusted. Lets EX-RAIL wait for
+  // the clock before acting on it, e.g. to pick a scene at startup.
+  static bool isSynced() { return synced; }
+
+private:
+  static bool configured;   // configTzTime() has been called
+  static bool synced;       // a plausible time has been seen
+  static unsigned long lastPoll;
+};
+
+#endif // ARDUINO_ARCH_ESP32 && NTP_CLOCK
+#endif // NtpClock_h

--- a/config.example.h
+++ b/config.example.h
@@ -369,3 +369,36 @@ The configuration file for DCC-EX Command Station
 // That is described further above.
 //
 /////////////////////////////////////////////////////////////////////////////////////
+//
+// NTP FAST CLOCK ON ESP32
+// Drives the fast clock from the ESP32 system clock, synchronised over the
+// internet by NTP. This gives you <JC> and the EX-RAIL ONCLOCKTIME /
+// ONCLOCKMINS triggers without a DS1307 chip or an EX-FastClock module.
+//
+// Requires WiFi in station mode (WIFI_FORCE_AP false and a reachable router);
+// in AP mode there is no route to an NTP server and the clock stays off.
+//
+//#define NTP_CLOCK
+//
+// Optional, shown with their defaults:
+//
+// Which time server to ask.
+//#define NTP_CLOCK_SERVER "pool.ntp.org"
+//
+// POSIX timezone string. The default is Central European Time with the EU
+// daylight saving rules. Examples:
+//   "CET-1CEST,M3.5.0,M10.5.0/3"  Central Europe (Berlin, Paris, Rome)
+//   "GMT0BST,M3.5.0/1,M10.5.0"    United Kingdom
+//   "UTC0"                        UTC, no daylight saving
+//#define NTP_CLOCK_TZ "CET-1CEST,M3.5.0,M10.5.0/3"
+//
+// How many model minutes pass per real minute, 1..127. With 1 the model clock
+// is the wall clock. With 12 a model day takes two real hours, which suits
+// scenery automation such as lighting scenes.
+//#define NTP_CLOCK_RATE 1
+//
+// Note that EX-RAIL ONCLOCKTIME triggers only fire when the minute is reached.
+// After a restart nothing happens until the next trigger time comes around,
+// so the layout keeps whatever state it powered up in until then.
+//
+/////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary  Refresh [upstream PR #528](https://github.com/DCC-EX/CommandStation-EX/pull/528) onto the repository default branch master. The original PR targets devel and carries unrelated devel history; this PR preserves only the focused NTP fast-clock delta: lazy SNTP setup after Wi-Fi station connection, timezone/rate configuration, and feeding the existing fast-clock API.  ## References and scope  - Related existing contribution: [CommandStation PR #528](https://github.com/DCC-EX/CommandStation-EX/pull/528). - Authoritative issue: no separate issue was identified in the live audit. - No healthy duplicate is being created; this is a current-master refresh with bounded history. - Personal integration code and unrelated protocol behavior are explicitly out of scope.  ## Validation evidence  - PR #528 was inspected as open, mergeable, and clean; its only reported check passed. - The repository has no existing automated test suite for this path. - PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`. - N/A - Fork-hosted CI: no Actions run exists for exact head `841979f968fb6f2587af33629f06313bf8ffa77d`; the available CommandStation fork CI is push-triggered and did not record a run for this head.
- N/A - Upstream PR workflows for this head are [Docs run 31940510431](https://github.com/DCC-EX/CommandStation-EX/actions/runs/31940510431) and [Label sponsors run 31940510488](https://github.com/DCC-EX/CommandStation-EX/actions/runs/31940510488), both `action_required` with no firmware jobs; neither is build validation.
- No runtime or hardware result is claimed. Hardware validation: not run - no hardware available. - Branch/base and ready-for-review status remain as shown in this PR.  ## Hardware validation  Hardware validation: Not run—no hardware available.  Maintainer bench criteria: on a supported ESP32 with Wi-Fi, verify NTP synchronization after station connection, configured timezone/rate behavior, clock updates through the existing API, loss/reconnect handling, and preserved configuration after reboot.  This PR is ready for maintainer review; runtime/hardware evidence remains outstanding; local five-environment compilation is complete.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `841979f968fb6f2587af33629f06313bf8ffa77d`; no hosted code-test result is claimed. Local validation above is the available evidence.
