### PR TITLE
Broadcast DCC accessory state changes

### DIFF
--- a/CommandDistributor.cpp
+++ b/CommandDistributor.cpp
@@ -177,7 +177,7 @@ void  CommandDistributor::broadcastSensor(int16_t id, bool on ) {
 }
 
 void CommandDistributor::broadcastAccessory(int16_t address, byte port, bool gate, bool on) {
-  broadcastReply(COMMAND_TYPE, F("<y A %d %d %d %d>\n"), address, port, gate, on);
+  broadcastReply(COMMAND_TYPE, F("<y a %d %d %d %d>\n"), address, port, gate, on);
 }
 
 void CommandDistributor::broadcastExtendedAccessory(int16_t address, int16_t value) {

--- a/CommandDistributor.cpp
+++ b/CommandDistributor.cpp
@@ -176,6 +176,14 @@ void  CommandDistributor::broadcastSensor(int16_t id, bool on ) {
   broadcastReply(COMMAND_TYPE, F("<%c %d>\n"), on?'Q':'q', id);
 }
 
+void CommandDistributor::broadcastAccessory(int16_t address, byte port, bool gate, bool on) {
+  broadcastReply(COMMAND_TYPE, F("<y A %d %d %d %d>\n"), address, port, gate, on);
+}
+
+void CommandDistributor::broadcastExtendedAccessory(int16_t address, int16_t value) {
+  broadcastReply(COMMAND_TYPE, F("<y E %d %d>\n"), address, value);
+}
+
 void  CommandDistributor::broadcastTurnout(int16_t id, bool isClosed ) {
   // For DCC++ classic compatibility, state reported to JMRI is 1 for thrown and 0 for closed;
   // The string below contains serial and Withrottle protocols which should

--- a/CommandDistributor.h
+++ b/CommandDistributor.h
@@ -50,6 +50,8 @@ public :
   static void broadcastLoco(LocoSlot * slot);
   static void broadcastForgetLoco(int16_t loco);
   static void broadcastSensor(int16_t id, bool value);
+  static void broadcastAccessory(int16_t address, byte port, bool gate, bool on);
+  static void broadcastExtendedAccessory(int16_t address, int16_t value);
   static void broadcastTurnout(int16_t id, bool isClosed);
   static void broadcastTurntable(int16_t id, uint8_t position, bool moving);
   static void broadcastClockTime(int16_t time, int8_t rate);

--- a/DCC.cpp
+++ b/DCC.cpp
@@ -394,10 +394,14 @@ void DCC::setAccessory(int address, byte port, bool gate, byte onoff /*= 2*/) {
   if (onoff==0) {   // off packet only
     b[1] &= ~0x08; // set C to 0
     DCCQueue::scheduleDCCPacket(b, 2, 3);
+    CommandDistributor::broadcastAccessory(address, port, gate, false);
   } else if (onoff==1) { // on packet only
     DCCQueue::scheduleDCCPacket(b, 2, 3);
+    CommandDistributor::broadcastAccessory(address, port, gate, true);
   } else { // auto timed on then off  
     DCCQueue::scheduleAccOnOffPacket(b, 2, 3, 100); // On then off after 100mS
+    CommandDistributor::broadcastAccessory(address, port, gate, true);
+    CommandDistributor::broadcastAccessory(address, port, gate, false);
   } 
 #if defined(EXRAIL_ACTIVE)
   if (onoff !=0) RMFT2::activateEvent(address<<2|port,gate);
@@ -452,6 +456,7 @@ whole range of the 11 bits sent to track.
     | ((address & 0x03)<<1);         // mask 2 bits, shift up 1
   b[2]=value;
   DCCQueue::scheduleDCCPacket(b, sizeof(b), repeats);
+  CommandDistributor::broadcastExtendedAccessory(address-3, value);
   return true;
 }
 

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -94,7 +94,7 @@ Once a new OPCODE is decided upon, update this list.
   W, Write CV
   x,
   X, Invalid command response
-  y, Output Sound
+  y, Accessory/extended accessory broadcast
   Y, Output broadcast
   z, Direct output
   Z, Output configuration/control

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -94,7 +94,7 @@ Once a new OPCODE is decided upon, update this list.
   W, Write CV
   x,
   X, Invalid command response
-  y, Accessory/extended accessory broadcast
+  y, Output Sound / accessory event broadcast
   Y, Output broadcast
   z, Direct output
   Z, Output configuration/control


### PR DESCRIPTION
## Status

This pull request is ready for maintainer review; broader supported-platform validation remains outstanding. The source protocol blocker identified during audit is corrected in commit [6c1d777](https://github.com/BanjoR/CommandStation-EX/commit/6c1d777): basic accessory events use the lowercase a subcommand documented by the authoritative issue, extended accessory events retain the distinct E subcommand, and the existing y Output Sound parser/documentation is preserved.

## Issue closure

Fixes #444

## References

- Authoritative issue: [DCC-EX/CommandStation-EX#444](https://github.com/DCC-EX/CommandStation-EX/issues/444)
- Superseded implementation: [DCC-EX/CommandStation-EX#445](https://github.com/DCC-EX/CommandStation-EX/pull/445), stale and merge-conflicting against the current tree.

## Bounded scope

This branch is limited to four source files:

- CommandDistributor.cpp and CommandDistributor.h: command-client accessory broadcast helpers.
- DCC.cpp: basic and extended accessory events after current DCCQueue scheduling.
- DCCEXParser.cpp: preserve the y Output Sound entry while documenting the accessory event broadcasts.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Validation evidence

- Exact PR head 6c1d777, clean checkout, and four-file allowlist verified.
- git diff --check: passed.
- Protocol contract check: basic broadcast is <y a address port gate on>; extended broadcast is <y E address value>; existing case y Output Sound parsing remains present.
- Exact default PlatformIO build: all five environments passed — mega2560, ESP32, Nucleo-F411RE, Nucleo-F446RE, and Nucleo-F429ZI.
- The repository has no host test directory or PlatformIO test target; no host-test pass is claimed.
- Exact-head fork CI: PASS - [CI run 31986759889](https://github.com/BanjoR/CommandStation-EX/actions/runs/31986759889) completed successfully for head 6c1d777117157038c78ef42c82f24167c52f6f8c.
- The upstream firmware workflow is push-triggered, so no pull-request firmware check is attached; ancillary Docs and Label sponsors statuses are not treated as firmware validation.

## Hardware validation

Not run — no hardware is available. Maintainer bench criteria: flash the exact PR head to a supported CommandStation, connect serial and network clients, verify the basic and extended accessory event sequences, retain single turnout transition behavior, and verify existing y sound commands remain functional.