### PR TITLE
Audit ESP32 ADC attenuation in motor-current conversion

### DIFF
--- a/DCCTimerESP.cpp
+++ b/DCCTimerESP.cpp
@@ -97,6 +97,12 @@ int DCCTimer::freeMemory() {
 #define ADC_INPUT_MAX_VALUE 4095 // 12 bit ADC
 #define pinToADC1Channel(X) (adc1_channel_t)(((X) > 35) ? (X)-36 : (X)-28)
 
+// ADC_ATTEN_11db selects the ESP32 ADC input range.  It does not belong in
+// MotorDriver's raw-to-mA conversion: adc1_get_raw() already returns the raw
+// code produced with this attenuation configured.  The sense_factor supplied
+// by each motor-shield definition is the calibration from that raw code to mA.
+// Do not change safety thresholds without a measured shield calibration.
+
 int IRAM_ATTR local_adc1_get_raw(int channel) {
   uint16_t adc_value;
   SENS.sar_meas_start1.sar1_en_pad = (1 << channel); // only one channel is selected

--- a/docs/ADC_Attenuation_Bench.md
+++ b/docs/ADC_Attenuation_Bench.md
@@ -1,0 +1,17 @@
+# ESP32 motor-current ADC attenuation
+
+Issue [#510](https://github.com/DCC-EX/CommandStation-EX/issues/510) reports that ESP32 motor-driver ADC inputs are configured for 11 dB attenuation. The code uses the raw ADC code returned after that configuration and applies the motor-shield-specific `sense_factor` in `MotorDriver::raw2mA()` and `MotorDriver::mA2raw()`.
+
+Attenuation must not be multiplied into the current conversion a second time. Existing `tripMilliamps` values must not be changed from attenuation alone: required electrical constants depend on the shield current-sense circuit, ADC pin protection, supply/reference behavior, and ESP32 ADC calibration.
+
+## Required hardware evidence before changing a threshold
+
+For each ESP32 board and motor-shield definition:
+
+1. Record the exact board, Arduino-ESP32 2.x/IDF 4 version, shield revision, current-sense details, and ADC GPIO.
+2. With track power off, record the ADC raw code at zero current after cold start and warm-up.
+3. Apply at least three measured loads across the intended range. Record calibrated current, ADC raw code, and attenuation at every point.
+4. Confirm the highest intended sense voltage is below the verified 11 dB input range and the raw code does not clip before the documented trip current.
+5. Demonstrate the measured trip point is within the maintainer-approved tolerance, then verify an excessive load enters `POWERMODE::OVERLOAD`.
+
+Attach raw measurements and instrument accuracy to any proposed change to `sense_factor`, `tripMilliamps`, `ADCmax()`, or overload thresholds.

--- a/test/test_adc_attenuation_contract.py
+++ b/test/test_adc_attenuation_contract.py
@@ -1,0 +1,25 @@
+"""Host-side regression checks for the ESP32 ADC attenuation contract."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_esp32_configures_attenuation_and_12_bit_raw_range():
+    source = (ROOT / "DCCTimerESP.cpp").read_text(encoding="utf-8")
+    assert "adc1_config_width(ADC_WIDTH_BIT_12)" in source
+    assert "ADC_ATTEN_11db" in source
+    assert "return 4095;" in source
+
+
+def test_motor_driver_keeps_calibration_in_sense_factor():
+    source = (ROOT / "MotorDriver.cpp").read_text(encoding="utf-8")
+    assert "raw * senseFactorInternal / senseScale" in source
+    assert "mA * senseScale / senseFactorInternal" in source
+    assert "ADC_ATTEN" not in source
+
+
+def test_bench_criteria_are_documented():
+    document = (ROOT / "docs" / "ADC_Attenuation_Bench.md").read_text(encoding="utf-8")
+    for required in ("zero current", "three measured loads", "raw code", "trip point"):
+        assert required in document


### PR DESCRIPTION
## Scope

This PR audits [upstream issue #510](https://github.com/DCC-EX/CommandStation-EX/issues/510) for ESP32 ADC attenuation handling.

Bounded changes in [commit cd17095](https://github.com/BanjoR/CommandStation-EX/commit/cd1709507bc8f80145581f36ebb617d973467607):

- Annotate the ESP32 ADC attenuation/raw-code contract in [`DCCTimerESP.cpp`](https://github.com/BanjoR/CommandStation-EX/blob/cd1709507bc8f80145581f36ebb617d973467607/DCCTimerESP.cpp).
- Add host-side source-contract regression checks in [`test/test_adc_attenuation_contract.py`](https://github.com/BanjoR/CommandStation-EX/blob/cd1709507bc8f80145581f36ebb617d973467607/test/test_adc_attenuation_contract.py).
- Document reproducible hardware acceptance criteria in [`docs/ADC_Attenuation_Bench.md`](https://github.com/BanjoR/CommandStation-EX/blob/cd1709507bc8f80145581f36ebb617d973467607/docs/ADC_Attenuation_Bench.md).

Explicit exclusions:

- No change to `tripMilliamps`, `MAX_CURRENT`, `ADCmax()`, `sense_factor`, overload thresholds, or ADC attenuation settings.
- No change to `MotorDriver.cpp`; its existing raw-to-mA and mA-to-raw formulas were audited and remain the calibration boundary.
- Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Superseded work

No superseded or duplicate upstream PR was found in the all-state search for `510` on 2026-08-16. This is the only matching upstream PR found: [PR #531](https://github.com/DCC-EX/CommandStation-EX/pull/531).

## Validation

- PASS — Full available host-side suite: `pytest -q -p no:cacheprovider <checkout>` → `3 passed in 0.19s`, return code 0.
- PASS — Focused regression: [`test/test_adc_attenuation_contract.py`](https://github.com/BanjoR/CommandStation-EX/blob/cd1709507bc8f80145581f36ebb617d973467607/test/test_adc_attenuation_contract.py) → `3 passed in 0.65s`, return code 0.
- PASS — Python AST parse of the focused test.
- PASS — `git diff --check upstream/master...HEAD`.
- PASS — `git show --check HEAD`.
- PASS — `git fsck --full --no-progress`.
- PASS — Clean working tree; no untracked or generated files detected after validation.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- No standalone native `g++`, `clang++`, or CMake test target was available; the focused Python regression remains the host-side test evidence.
- CI — The repository [CI workflow](https://github.com/DCC-EX/CommandStation-EX/blob/master/.github/workflows/main.yml) runs on push, not pull request; [no checks were reported](https://github.com/DCC-EX/CommandStation-EX/pull/531/checks) on this PR. The PR-triggered [Docs run](https://github.com/DCC-EX/CommandStation-EX/actions/runs/31941243028) and [Label sponsors run](https://github.com/DCC-EX/CommandStation-EX/actions/runs/31941243015) completed with `action_required` and zero jobs, so neither is a validation result.

## Hardware validation

Not run—no hardware available.

Maintainer bench criteria before changing any calibration or safety threshold:

1. Record the exact ESP32 board, Arduino-ESP32 2.x/IDF 4 version, shield revision, current-sense circuit details, and ADC GPIO.
2. With track power off, record the ADC raw code at zero current after cold start and warm-up.
3. Apply at least three measured loads across the intended range; record calibrated current, ADC raw code, configured attenuation, and both track polarities where applicable.
4. Confirm the highest intended sense voltage is below the verified 11 dB input range and that raw ADC codes do not clip before the documented trip current.
5. Verify the measured trip point against maintainer-approved tolerance and verify an excessive load enters `POWERMODE::OVERLOAD`.

This PR is ready for maintainer review; hardware evidence remains outstanding; the exact local five-environment build above is complete.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `cd1709507bc8f80145581f36ebb617d973467607`; no hosted code-test result is claimed. Local validation above is the available evidence.
