### PR TITLE
Add EXRAIL IF_ESTOP_PAUSED predicate

### DIFF
--- a/EXRAIL2.cpp
+++ b/EXRAIL2.cpp
@@ -1250,6 +1250,9 @@ void RMFT2::loop2() {
   case OPCODE_IF_ROUTE_DISABLED:
     skipIf=!ifRouteState(operand,4);
     break;   
+  case OPCODE_IF_ESTOP_PAUSED:
+    skipIf=!DCC::isEstopLocked();
+    break;
 
   case OPCODE_STASH:
     Stash::set(operand,invert? -loco : loco);

--- a/EXRAIL2.h
+++ b/EXRAIL2.h
@@ -110,6 +110,7 @@ enum OPCODE : byte {OPCODE_THROW,OPCODE_CLOSE,OPCODE_TOGGLE_TURNOUT,
              OPCODE_IFBITMAP_ALL,OPCODE_IFBITMAP_ANY,
              OPCODE_IF_ROUTE_ACTIVE,OPCODE_IF_ROUTE_INACTIVE,
              OPCODE_IF_ROUTE_HIDDEN,OPCODE_IF_ROUTE_DISABLED,
+             OPCODE_IF_ESTOP_PAUSED,
              };
 
 // Ensure thrunge_lcd is put last as there may be more than one display, 

--- a/EXRAIL2MacroBase.h
+++ b/EXRAIL2MacroBase.h
@@ -213,6 +213,9 @@
 #define ESTOP_RESUME
 ///brief Resumes loco speeds after ESTOP_PAUSE
 
+#define IF_ESTOP_PAUSED
+///brief Executes the following block while the global ESTOP_PAUSE lock is active
+
 #define EXRAIL
 ///brief obsolete.. no longer needed. Does nothing.
 

--- a/EXRAIL2MacroReset.h
+++ b/EXRAIL2MacroReset.h
@@ -67,6 +67,7 @@
 #undef ESTOPALL
 #undef ESTOP_PAUSE
 #undef ESTOP_RESUME
+#undef IF_ESTOP_PAUSED
 #undef EXRAIL
 #undef EXTT_TURNTABLE
 #undef FADE

--- a/EXRAILMacros.h
+++ b/EXRAILMacros.h
@@ -592,6 +592,7 @@ int RMFT2::onLCCLookup[RMFT2::countLCCLookup];
 #define IFROUTE_INACTIVE(sequence_id) OPCODE_IF_ROUTE_INACTIVE,V(sequence_id),
 #define IFROUTE_HIDDEN(sequence_id) OPCODE_IF_ROUTE_HIDDEN,V(sequence_id),
 #define IFROUTE_DISABLED(sequence_id) OPCODE_IF_ROUTE_DISABLED,V(sequence_id),
+#define IF_ESTOP_PAUSED OPCODE_IF_ESTOP_PAUSED,0,0,
 #define IFSTASH(stash_id) OPCODE_IFSTASH,V(stash_id),
 #define IFSTASHED_HERE(stash_id) OPCODE_IFSTASHED_HERE,V(stash_id),
 #define IFTHROWN(turnout_id) OPCODE_IFTHROWN,V(turnout_id),

--- a/EXRAILTest.h
+++ b/EXRAILTest.h
@@ -199,6 +199,21 @@ ROUTE(8001,"8001 ESTOP_RESUME test")
    ZTEST("<D CABS>",DCC::getLocoSpeedByte(3)==(128+20))
    DONE
 
+ROUTE(8002,"8002 IF_ESTOP_PAUSED test")
+   ESTOP_PAUSE
+   IF_ESTOP_PAUSED
+     PRINT("8002 pause predicate passed")
+   ELSE
+     PRINT("8002 pause predicate failed")
+   ENDIF
+   ESTOP_RESUME
+   IF_ESTOP_PAUSED
+     PRINT("8002 resume predicate failed")
+   ELSE
+     PRINT("8002 resume predicate passed")
+   ENDIF
+   DONE
+
 
 #define MYGROUP 1,2,3,4   
 ROUTE(1771,"1771 Test IFLOCO with multiple loco ids")

--- a/host_tests/test_exrail_estop.py
+++ b/host_tests/test_exrail_estop.py
@@ -1,0 +1,26 @@
+"""Host-side structural checks for the EXRAIL E-stop predicate."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(name):
+    return (ROOT / name).read_text(encoding="utf-8")
+
+
+def test_if_estop_paused_is_wired_once():
+    assert read("EXRAILMacros.h").count("#define IF_ESTOP_PAUSED") == 1
+    assert read("EXRAIL2.h").count("OPCODE_IF_ESTOP_PAUSED") == 1
+    assert read("EXRAIL2MacroReset.h").count("#undef IF_ESTOP_PAUSED") == 1
+    assert read("EXRAIL2MacroBase.h").count("#define IF_ESTOP_PAUSED") == 1
+
+
+def test_predicate_is_fail_safe_and_three_bytes():
+    assert "skipIf=!DCC::isEstopLocked();" in read("EXRAIL2.cpp")
+    assert "ESTOP_PAUSE" in read("EXRAILTest.h")
+    assert "ESTOP_RESUME" in read("EXRAILTest.h")
+    assert "IF_ESTOP_PAUSED" in read("EXRAILTest.h")
+    assert "#define IF_ESTOP_PAUSED OPCODE_IF_ESTOP_PAUSED,0,0," in read(
+        "EXRAILMacros.h"
+    )


### PR DESCRIPTION
## Automatic issue closing

Fixes #520

## Scope

Adds the EXRAIL `IF_ESTOP_PAUSED` predicate requested by [issue #520](https://github.com/DCC-EX/CommandStation-EX/issues/520). The predicate reads the existing global DCC E-stop lock and is true only while `ESTOP_PAUSE` is active; it is read-only and cannot unlock or resume motion.

[Issue #420](https://github.com/DCC-EX/CommandStation-EX/issues/420) supplies the heartbeat safety context. This PR does not change heartbeat handling or protocol behavior. The safety contract for this predicate is: heartbeat loss may cause an E-stop, but must never clear the E-stop lock or resume motion.

## Bounded changes

- Add one EXRAIL opcode, macro definition, documentation declaration, and macro reset entry.
- Evaluate the opcode using `DCC::isEstopLocked()`.
- Add EXRAIL route 8002 covering the paused and resumed states.
- Add host-side structural/resource checks in `host_tests/test_exrail_estop.py`.

## Explicit exclusions

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Related and superseded work

- Superseded PRs: none identified in the current and historical upstream PR search.
- Related historical heartbeat work: [PR #43](https://github.com/DCC-EX/CommandStation-EX/pull/43); it is not superseded by this EXRAIL predicate change.

## Validation — passed

- Host suite: `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider` — `2 passed`.
- Python AST syntax parse — passed.
- `git diff --check origin/master...HEAD` — passed.
- Changed-file allowlist — passed: exactly `EXRAIL2.cpp`, `EXRAIL2.h`, `EXRAIL2MacroBase.h`, `EXRAIL2MacroReset.h`, `EXRAILMacros.h`, `EXRAILTest.h`, and `host_tests/test_exrail_estop.py`.
- Resource check — passed structurally: one opcode plus two zero operand bytes, 3 bytes per use, with no persistent runtime storage added.

## Additional validation

- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- The repository has no native host/CMake test target for this path; the focused EXRAIL structural/resource tests remain the host-side evidence.
- Exact-head fork CI: PASS - [CI run 31944366724](https://github.com/BanjoR/CommandStation-EX/actions/runs/31944366724) completed successfully for head cc5d7f9c7c7b9ca90654371a60e7446be8c890ae.
- The upstream firmware workflow is push-triggered, so no pull-request firmware check is attached; the exact-head fork run above is the available hosted build evidence.
- Hardware: Not run—no hardware available. Maintainer bench criteria: load the EXRAIL test automation, run route 8002, verify the paused branch is taken while the global lock is set and the resumed branch is taken only after `ESTOP_RESUME`; independently confirm that an active loco receives/stays at emergency stop during the lock and that no heartbeat event clears the lock or resumes motion without explicit resume.

The PR is ready for maintainer review.