### PR TITLE
Add CommandStation metadata contract for EX-Installer

### DIFF
--- a/CommandStation-Metadata.md
+++ b/CommandStation-Metadata.md
@@ -1,0 +1,16 @@
+# CommandStation metadata contract
+
+CommandStation-EX exposes product, device, and release identity through this
+newline-terminated information frame:
+
+```
+<iDCC-EX V-5.6.3 / ARDUINO_TYPE / MOTOR_SHIELD G-GITHUB_SHA>
+```
+
+Host tools may request it with the side-effect-free `<i>` command. The same
+frame remains emitted during startup and as part of the existing `<s>` status
+response, preserving compatibility with current clients.
+
+Fields are positional and delimited by ` / `: product, release, device, and
+build SHA. Hosts should tolerate future fields and use the release field for
+display or compatibility-matrix lookup rather than assuming a fixed version.

--- a/DCC.cpp
+++ b/DCC.cpp
@@ -66,7 +66,7 @@ byte DCC::globalSpeedsteps=128;
 #define SLOTLOOP for (auto slot=LocoSlot::getFirst();slot;slot=slot->getNext())
 
 void DCC::begin() {
-  StringFormatter::send(&USB_SERIAL,F("<iDCC-EX V-%S / %S / %S G-%S>\n"), F(VERSION), F(ARDUINO_TYPE), shieldName, F(GITHUB_SHA));
+  printMetadata(&USB_SERIAL);
 #ifndef DISABLE_EEPROM
   // Load stuff from EEprom
   (void)EEPROM; // tell compiler not to warn this is unused
@@ -75,6 +75,11 @@ void DCC::begin() {
 #ifndef ARDUINO_ARCH_ESP32 /* On ESP32 started in TrackManager::setTrackMode() */
   DCCWaveform::begin();
 #endif
+}
+
+void DCC::printMetadata(Print *stream) {
+  StringFormatter::send(stream, F("<iDCC-EX V-%S / %S / %S G-%S>\n"),
+                        F(VERSION), F(ARDUINO_TYPE), shieldName, F(GITHUB_SHA));
 }
 
 byte DCC::defaultMomentumA=0;

--- a/DCC.h
+++ b/DCC.h
@@ -47,6 +47,8 @@ public:
     shieldName=(FSH *)motorShieldName;
   };
   static void begin();
+  // Emit the product/device/release metadata contract used by host tools.
+  static void printMetadata(Print *stream);
   static void loop();
 
   // Public DCC API functions

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -716,8 +716,13 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
         Sensor::printAll(stream);
         return;
 
+    case 'i': // PRODUCT/DEVICE/RELEASE METADATA <i>
+        if (params != 0) break;
+        DCC::printMetadata(stream);
+        return;
+
     case 's': // STATUS <s>
-        StringFormatter::send(stream, F("<iDCC-EX V-%S / %S / %S G-%S>\n"), F(VERSION), F(ARDUINO_TYPE), DCC::getMotorShieldName(), F(GITHUB_SHA));
+        DCC::printMetadata(stream);
         CommandDistributor::broadcastPower(); // <s> is the only "get power status" command we have
         Turnout::printAll(stream); //send all Turnout states
         Sensor::printAll(stream);  //send all Sensor  states

--- a/tools/metadata_contract_test.py
+++ b/tools/metadata_contract_test.py
@@ -1,0 +1,17 @@
+"""Regression checks for the CommandStation host metadata contract."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DCC = (ROOT / "DCC.cpp").read_text(encoding="utf-8")
+PARSER = (ROOT / "DCCEXParser.cpp").read_text(encoding="utf-8")
+DOC = (ROOT / "CommandStation-Metadata.md").read_text(encoding="utf-8")
+
+
+assert DCC.count("void DCC::printMetadata(Print *stream)") == 1
+assert DCC.count("printMetadata(&USB_SERIAL)") == 1
+assert PARSER.count("case 'i': // PRODUCT/DEVICE/RELEASE METADATA <i>") == 1
+assert PARSER.count("DCC::printMetadata(stream);") == 2
+assert "side-effect-free `<i>` command" in DOC
+assert "<iDCC-EX V-" in DCC


### PR DESCRIPTION
## Summary

This is a CommandStation-EX metadata contract change for EX-Installer host discovery. It adds a backward-compatible, side-effect-free <i> query that returns the established product/device/release information frame, centralizes the existing startup and <s> responses, and documents the field contract.

## References

- Related context only: [CommandStation issue #415](https://github.com/DCC-EX/CommandStation-EX/issues/415) reports an EX-Installer antivirus classification; this metadata contract does not claim to resolve that security-tool behavior.
- Superseded PRs: none identified during the live duplicate audit.
- No installer source is included; the EX-Installer consumer remains a separate sibling contribution.

## Scope and exclusions

- CommandStation metadata response and its tests/documentation only.
- Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Validation evidence

- tools/metadata_contract_test.py passed with the bundled Python runtime.
- git diff --check against upstream/master passed.
- Clean task-owned checkout and exact five-file allowlist verified.
- Exact-head fork CI: PASS - [CI run 31946738885](https://github.com/BanjoR/CommandStation-EX/actions/runs/31946738885) completed successfully for head b0f5b4fadea10a5bd8e01c36c74a28b13caa0b6e.
- The upstream firmware workflow is push-triggered, so no pull-request firmware check is attached; the exact-head fork run above is the available hosted build evidence.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.

## Hardware validation

Hardware validation: Not run—no hardware available.

Maintainer bench criteria: query <i> and <s> on a supported CommandStation, verify stable field ordering and values, then run the EX-Installer discovery flow against the returned metadata without changing existing clients.

This PR is ready for maintainer review; CI validation remains outstanding.