### PR TITLE
Add opt-in GPIO auto power-off for issue #309

### DIFF
--- a/AUTO_POWER_OFF.md
+++ b/AUTO_POWER_OFF.md
@@ -1,0 +1,29 @@
+# Automatic track power-off
+
+Automatic power-off is opt-in. Define both `AUTO_POWER_OFF_PIN` and
+`AUTO_POWER_OFF_TIMEOUT_MS` in `config.h` to select the relay GPIO and a
+non-zero millisecond timeout. The default is disabled because neither macro
+is defined, so existing installations retain their current behavior.
+
+The relay GPIO is configured as an output and driven `HIGH` after track setup.
+The timer is re-armed by every received command, regardless of command type.
+When the timeout expires, the GPIO is driven `LOW` once. This cuts the
+station's external supply; track power commands and overload/emergency-stop
+handling remain unchanged.
+
+This is an inactivity timeout, not an occupancy, current, or emergency-stop
+detector. Keep existing motor-shield overload and emergency-stop protections.
+
+## Validation
+
+Run `python tests/test_auto_poweroff_timing.py` for deterministic deadline,
+re-arm, one-shot, disabled-default, and `millis()` wraparound checks. CI must
+also compile a normal supported PlatformIO target.
+
+Before enabling it on hardware, verify the relay is HIGH after boot, every
+command source refreshes it, it goes LOW by the deadline plus one main-loop
+scheduling interval, and it does not chatter or retrigger. Verify the relay's
+LOW state actually removes station supply, that startup polarity is safe for
+the chosen relay board, and that a disabled/default build leaves the GPIO
+untouched during a soak test. Keep an independent emergency-stop and overload
+path; this timeout is not an occupancy or current detector.

--- a/AutoPowerOff.h
+++ b/AutoPowerOff.h
@@ -1,0 +1,20 @@
+#ifndef AutoPowerOff_h
+#define AutoPowerOff_h
+#include <stdint.h>
+class AutoPowerOff {
+  public:
+    typedef void (*PowerOffCallback)();
+    AutoPowerOff(uint32_t timeout, PowerOffCallback callback)
+      : timeoutMs(timeout), callback(callback), lastActivity(0), armed(false) {}
+    void begin(uint32_t now) { lastActivity=now; armed=timeoutMs != 0; }
+    void activity(uint32_t now) { lastActivity=now; armed=timeoutMs != 0; }
+    bool loop(uint32_t now) {
+      if (!armed || (uint32_t)(now-lastActivity) < timeoutMs) return false;
+      armed=false; if (callback) callback(); return true;
+    }
+  private:
+    uint32_t timeoutMs, lastActivity;
+    PowerOffCallback callback;
+    bool armed;
+};
+#endif

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -309,6 +309,7 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
     int16_t p[MAX_COMMAND_PARAMS];
     while (com[0] == '<' || com[0] == ' ')
         com++; // strip off any number of < or spaces
+    TrackManager::autoPowerOffActivity();
     byte opcode = com[0];
     int16_t splitnum = splitValues(p, com, opcode=='M' || opcode=='P');
     if (splitnum < 0 || splitnum >= MAX_COMMAND_PARAMS) // if arguments are broken, leave but via printing <X>

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -32,6 +32,7 @@
 #include "CommandDistributor.h"
 #include "DCCEXParser.h"
 #include "KeywordHasher.h"
+#include "AutoPowerOff.h"
 // Virtualised Motor shield multi-track hardware Interface
 #define FOR_EACH_TRACK(t) for (byte t=0;t<=lastTrack;t++)
     
@@ -51,6 +52,14 @@ int16_t TrackManager::joinRelay=UNUSED_PIN;
 #ifdef ARDUINO_ARCH_ESP32
 byte TrackManager::tempProgTrack=MAX_TRACKS+1; // MAX_TRACKS+1 is the unused flag
 #endif
+
+#if defined(AUTO_POWER_OFF_PIN) && defined(AUTO_POWER_OFF_TIMEOUT_MS)
+static void autoPowerOffRelayOff() { digitalWrite(AUTO_POWER_OFF_PIN, LOW); }
+static AutoPowerOff trackAutoPowerOff(AUTO_POWER_OFF_TIMEOUT_MS, autoPowerOffRelayOff);
+#else
+static AutoPowerOff trackAutoPowerOff(0, NULL);
+#endif
+void TrackManager::autoPowerOffActivity() { trackAutoPowerOff.activity(millis()); }
 
 #ifdef ANALOG_READ_INTERRUPT
 /*
@@ -131,6 +140,11 @@ void TrackManager::Setup(const FSH * shieldname,
     }
   }
   DCC::setShieldName(shieldname);
+#if defined(AUTO_POWER_OFF_PIN) && defined(AUTO_POWER_OFF_TIMEOUT_MS)
+  pinMode(AUTO_POWER_OFF_PIN, OUTPUT);
+  digitalWrite(AUTO_POWER_OFF_PIN, HIGH);
+#endif
+  trackAutoPowerOff.begin(millis());
 }
 
 void TrackManager::addTrack(byte t, MotorDriver* driver) {
@@ -504,6 +518,7 @@ void TrackManager::streamTrackState(Print* stream, byte t) {
 byte TrackManager::nextCycleTrack=MAX_TRACKS;
 
 void TrackManager::loop() {
+    trackAutoPowerOff.loop(millis());
     DCCWaveform::loop();
 #ifndef DISABLE_PROG
     DCCACK::loop();

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -76,6 +76,7 @@ class TrackManager {
     static bool setTrackMode(byte track, TRACK_MODE mode, int16_t DCaddr=0, bool offAtChange=true);
     static bool parseEqualSign(Print * stream,  int16_t params, int16_t p[]);
     static void loop();
+    static void autoPowerOffActivity();
     static POWERMODE getMainPower();
     static POWERMODE getProgPower();
     static inline POWERMODE getPower(byte t) { return track[t]->getPower(); }

--- a/config.example.h
+++ b/config.example.h
@@ -28,6 +28,11 @@ The configuration file for DCC-EX Command Station
 
 **********************************************************************/
 
+// Optional external station-supply relay. Define both macros to opt in.
+// AUTO_POWER_OFF_PIN is driven HIGH after startup and LOW after inactivity.
+// #define AUTO_POWER_OFF_PIN 7
+// #define AUTO_POWER_OFF_TIMEOUT_MS 600000UL
+
 /////////////////////////////////////////////////////////////////////////////////////
 // If you want to add your own motor driver definition(s), add them here
 //   For example MY_SHIELD with display name "MINE":

--- a/tests/test_auto_poweroff_timing.py
+++ b/tests/test_auto_poweroff_timing.py
@@ -1,0 +1,58 @@
+"""Host timing and source-hook tests for the AutoPowerOff policy contract."""
+
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+track_manager = (root / "TrackManager.cpp").read_text()
+parser = (root / "DCCEXParser.cpp").read_text()
+config = (root / "config.example.h").read_text()
+assert "defined(AUTO_POWER_OFF_PIN) && defined(AUTO_POWER_OFF_TIMEOUT_MS)" in track_manager
+assert "digitalWrite(AUTO_POWER_OFF_PIN, HIGH)" in track_manager
+assert "digitalWrite(AUTO_POWER_OFF_PIN, LOW)" in track_manager
+assert parser.count("TrackManager::autoPowerOffActivity();") == 1
+assert "#define AUTO_POWER_OFF_PIN" in config
+assert "#define AUTO_POWER_OFF_TIMEOUT_MS" in config
+
+UINT32 = 1 << 32
+
+class Timer:
+    def __init__(self, timeout, callback):
+        self.timeout = timeout
+        self.callback = callback
+        self.last = 0
+        self.armed = False
+
+    def begin(self, now):
+        self.last, self.armed = now & 0xffffffff, self.timeout != 0
+
+    def activity(self, now):
+        self.last, self.armed = now & 0xffffffff, self.timeout != 0
+
+    def loop(self, now):
+        elapsed = ((now & 0xffffffff) - self.last) & 0xffffffff
+        if not self.armed or elapsed < self.timeout:
+            return False
+        self.armed = False
+        self.callback()
+        return True
+
+calls = []
+disabled = Timer(0, lambda: calls.append("disabled"))
+disabled.begin(1000)
+assert not disabled.loop(1000000) and not calls
+
+timer = Timer(1000, lambda: calls.append("off"))
+timer.begin(1000)
+assert not timer.loop(1999)
+assert timer.loop(2000) and calls == ["off"]
+assert not timer.loop(3000)
+timer.activity(4000)
+assert not timer.loop(4999)
+assert timer.loop(5000) and calls == ["off", "off"]
+
+wrapped = Timer(100, lambda: calls.append("wrap"))
+wrapped.begin(UINT32 - 50)
+assert not wrapped.loop(49)
+assert wrapped.loop(50) and calls[-1] == "wrap"
+
+print("auto-poweroff timing tests passed")


### PR DESCRIPTION
## Automatic issue closing

Fixes #309

## Scope

Add an opt-in GPIO relay inactivity timer for the CommandStation external supply:

- Define `AUTO_POWER_OFF_PIN` and `AUTO_POWER_OFF_TIMEOUT_MS` in `config.h` to opt in.
- Drive the relay HIGH after track setup, refresh the timer for each received command, and drive it LOW once after the timeout.
- Add the bounded host timing/source-hook test and maintainer hardware-validation criteria.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Related issue and PR history

- Authoritative issue: [DCC-EX/CommandStation-EX#309](https://github.com/DCC-EX/CommandStation-EX/issues/309)
- Superseded PRs: none identified; this is the single PR for this task.

## Verified validation

- PASS — [host timing/source-hook test](https://github.com/BanjoR/CommandStation-EX/blob/4cff57c8b439150c469ff9efe0019fc496ad4d94/tests/test_auto_poweroff_timing.py): `python tests/test_auto_poweroff_timing.py` passed.
- PASS — Python 3.12.13 syntax check with `python -m py_compile tests/test_auto_poweroff_timing.py`; the audit cache artifact was removed.
- PASS — `git diff HEAD^ HEAD --check`.
- LIMITED — `python -m unittest discover -s tests -v` discovered 0 tests; no additional runnable repository test suite is present.

## CI and hardware limits

- CI unavailable in the upstream PR context because the firmware workflow is push-triggered; the exact local five-environment matrix above passed.
- Fork Actions run [31946781833](https://github.com/BanjoR/CommandStation-EX/actions/runs/31946781833) for current head `4cff57c8b439150c469ff9efe0019fc496ad4d94` completed successfully.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- Hardware validation not run - no hardware is available. Maintainer bench criteria: define a test relay GPIO and short timeout; measure HIGH after setup, send commands before and after the deadline, measure LOW within one main-loop scheduling interval after expiry, confirm the relay removes station supply, confirm no retrigger/chatter, verify safe startup polarity, and repeat with both macros undefined to confirm the default build leaves the GPIO untouched.

This PR is ready for maintainer review; hardware bench criteria remain outstanding; the exact local firmware matrix and current fork CI run have passed.