### PR TITLE
Add cooperative S88/S88-N feedback HAL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,11 @@ jobs:
       run: pip install -U platformio
     - name: Copy generic config over
       run: cp config.example.h config.h
+    - name: Static S88 regression checks
+      run: python S88_host_test.py
     - name: Compile Command Station (AVR)
       run: python -m platformio run
+    - name: Compile S88 HAL (Mega)
+      run: python -m platformio run -e mega2560-s88
+    - name: Compile S88 HAL (Teensy)
+      run: python -m platformio run -e Teensy3_2-s88

--- a/IODevice.cpp
+++ b/IODevice.cpp
@@ -21,11 +21,17 @@
 
 
 #include <Arduino.h>
+#include "defines.h"
 #include "IODevice.h"
+#include "IO_S88.h"
 #include "DIAG.h" 
 #include "FSH.h"
 #include "IO_MCP23017.h"
 #include "DCCTimer.h"
+
+#if defined(IO_NO_HAL) && defined(S88_NUM_PINS) && S88_NUM_PINS > 0
+#error "S88 configuration requires a build with HAL enabled"
+#endif
 
 #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
 #define USE_FAST_IO
@@ -60,6 +66,56 @@ void IODevice::begin() {
   // create something that conflicts with the user's vpin definitions. 
   if (halSetup)
     halSetup();
+
+  // Optional config.h shortcut for one directly connected S88 chain.  More
+  // than one chain can be created with S88::create() from myHal.cpp or EX-RAIL.
+#if defined(S88_NUM_PINS)
+#if S88_NUM_PINS > 0
+#if !defined(S88_FIRST_VPIN) || !defined(S88_CLOCK_PIN) || \
+    !defined(S88_LOAD_PIN) || !defined(S88_RESET_PIN) || \
+    !defined(S88_DATA_PIN)
+#error "S88_NUM_PINS requires S88_FIRST_VPIN, S88_CLOCK_PIN, S88_LOAD_PIN, S88_RESET_PIN, and S88_DATA_PIN"
+#endif
+#ifndef S88_CLOCK_PERIOD_MICROS
+#define S88_CLOCK_PERIOD_MICROS S88::DEFAULT_CLOCK_PERIOD_MICROS
+#endif
+#ifndef S88_SCAN_INTERVAL_MICROS
+#define S88_SCAN_INTERVAL_MICROS S88::DEFAULT_SCAN_INTERVAL_MICROS
+#endif
+#ifndef S88_INVERT_DATA
+#define S88_INVERT_DATA false
+#endif
+#ifndef S88_DATA_PULLUP
+#define S88_DATA_PULLUP false
+#endif
+  static_assert(S88_NUM_PINS <= S88::MAX_PINS,
+    "S88_NUM_PINS exceeds the supported VPIN/resource limit");
+  static_assert(S88::stateBytes(S88_NUM_PINS) <= S88::MAX_STATE_BYTES,
+    "S88_NUM_PINS exceeds the supported state storage limit");
+  static_assert(S88_CLOCK_PERIOD_MICROS >= S88::MIN_CLOCK_PERIOD_MICROS,
+    "S88 clock period is shorter than the S88-N minimum");
+  static_assert((S88_CLOCK_PERIOD_MICROS & 1) == 0,
+    "S88 clock period must be even so high and low phases are equal");
+  static_assert(S88_CLOCK_PIN != S88_LOAD_PIN &&
+                S88_CLOCK_PIN != S88_RESET_PIN &&
+                S88_CLOCK_PIN != S88_DATA_PIN &&
+                S88_LOAD_PIN != S88_RESET_PIN &&
+                S88_LOAD_PIN != S88_DATA_PIN &&
+                S88_RESET_PIN != S88_DATA_PIN,
+    "S88 control and data pins must be distinct");
+#if defined(NUM_DIGITAL_PINS)
+  static_assert(S88_CLOCK_PIN >= 0 && S88_CLOCK_PIN < NUM_DIGITAL_PINS &&
+                S88_LOAD_PIN >= 0 && S88_LOAD_PIN < NUM_DIGITAL_PINS &&
+                S88_RESET_PIN >= 0 && S88_RESET_PIN < NUM_DIGITAL_PINS &&
+                S88_DATA_PIN >= 0 && S88_DATA_PIN < NUM_DIGITAL_PINS,
+    "S88 pins must exist on the selected Arduino board");
+#endif
+  S88::create(S88_FIRST_VPIN, S88_NUM_PINS,
+              S88_CLOCK_PIN, S88_LOAD_PIN, S88_RESET_PIN, S88_DATA_PIN,
+              S88_CLOCK_PERIOD_MICROS, S88_SCAN_INTERVAL_MICROS,
+              S88_INVERT_DATA, S88_DATA_PULLUP);
+#endif
+#endif
 
   // Include any HAL devices defined in exrail.
   // The first pass call only creates HAL devices, 

--- a/IODeviceList.h
+++ b/IODeviceList.h
@@ -39,6 +39,7 @@ It has been moved here to be easier to maintain than editing IODevice.h
 #include "IO_PCF8574.h"
 #include "IO_PCF8575.h"
 #include "IO_RotaryEncoder.h"
+#include "IO_S88.h"
 #include "IO_Servo.h"
 #include "IO_TCA8418.h"
 #include "IO_TM1638.h"

--- a/IO_S88.h
+++ b/IO_S88.h
@@ -1,0 +1,357 @@
+/*
+ *  S88 and S88-N feedback bus HAL driver.
+ *
+ *  This file is part of CommandStation-EX
+ *
+ *  This is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This driver deliberately uses the cooperative IODevice scheduler.  S88
+ *  devices are allowed to require relatively long clock high and low times;
+ *  doing one edge per scheduler entry avoids blocking the DCC and command
+ *  station loops while the bus is being shifted.
+ */
+
+#ifndef IO_S88_H
+#define IO_S88_H
+
+#include <Arduino.h>
+#include "DIAG.h"
+#include "IODevice.h"
+
+class S88 : public IODevice {
+public:
+  // The IODevice overlap API uses an 8-bit pin count.  Keep the same limit
+  // here so a wrapped count can never silently allocate the wrong VPIN range.
+  static const uint16_t MAX_PINS = 255;
+  static const uint16_t MAX_STATE_BYTES = 32;
+  static const uint32_t MIN_CLOCK_PERIOD_MICROS = 30;
+  static const uint32_t DEFAULT_CLOCK_PERIOD_MICROS = 200;
+  static const uint32_t DEFAULT_SCAN_INTERVAL_MICROS = 10000;
+
+  static constexpr uint16_t stateBytes(uint16_t nPins) {
+    return (nPins + 7) / 8;
+  }
+
+  static_assert(stateBytes(MAX_PINS) <= MAX_STATE_BYTES,
+    "S88 state storage limit must cover the supported VPIN range");
+
+  /*
+   * Create one S88 chain.
+   *
+   * The first bit shifted out by the chain is exposed at firstVpin.  A
+   * complete S88 frame is shifted before scanIntervalMicros is added as an
+   * idle gap.  clockPeriodMicros is the complete clock period, so each high
+   * and low phase is approximately half that value.
+   */
+  static void create(VPIN firstVpin, uint16_t nPins,
+                     uint8_t clockPin, uint8_t loadPin,
+                     uint8_t resetPin, uint8_t dataPin,
+                     uint32_t clockPeriodMicros = DEFAULT_CLOCK_PERIOD_MICROS,
+                     uint32_t scanIntervalMicros = DEFAULT_SCAN_INTERVAL_MICROS,
+                     bool invertData = false,
+                     bool dataPullup = false) {
+#if defined(IO_NO_HAL)
+    // The small IO_NO_HAL build has no device list to attach to.  Keep the
+    // API harmless if an automation file is shared with a full HAL build.
+    (void)firstVpin;
+    (void)nPins;
+    (void)clockPin;
+    (void)loadPin;
+    (void)resetPin;
+    (void)dataPin;
+    (void)clockPeriodMicros;
+    (void)scanIntervalMicros;
+    (void)invertData;
+    (void)dataPullup;
+    return;
+#else
+    if (!validParameters(firstVpin, nPins, clockPin, loadPin, resetPin,
+                         dataPin, clockPeriodMicros)) {
+      DIAG(F("S88: invalid configuration"));
+      return;
+    }
+    if (!IODevice::checkNoOverlap(firstVpin, (uint8_t)nPins))
+      return;
+
+    S88 *device = new S88(firstVpin, nPins, clockPin, loadPin, resetPin,
+                          dataPin, clockPeriodMicros, scanIntervalMicros,
+                          invertData, dataPullup);
+    if (!device->_ready)
+      delete device;
+#endif
+  }
+
+private:
+  enum Step : uint8_t {
+    STEP_START,
+    STEP_LOAD_CLOCK_HIGH,
+    STEP_LOAD_CLOCK_LOW,
+    STEP_RELEASE_LOAD,
+    STEP_SAMPLE_FIRST,
+    STEP_RELEASE_RESET,
+    STEP_CLOCK_HIGH,
+    STEP_CLOCK_LOW,
+    STEP_SAMPLE_CLOCKED,
+    STEP_FINISH,
+    STEP_PUBLISH
+  };
+
+  S88(VPIN firstVpin, uint16_t nPins,
+      uint8_t clockPin, uint8_t loadPin,
+      uint8_t resetPin, uint8_t dataPin,
+      uint32_t clockPeriodMicros, uint32_t scanIntervalMicros,
+      bool invertData, bool dataPullup) :
+    IODevice(firstVpin, (int)nPins),
+    _clockPin(clockPin),
+    _loadPin(loadPin),
+    _resetPin(resetPin),
+    _dataPin(dataPin),
+    _phaseMicros(clockPeriodMicros / 2),
+    _scanIntervalMicros(scanIntervalMicros),
+    _invertData(invertData),
+    _dataPullup(dataPullup),
+    _stateByteCount(stateBytes(nPins)) {
+    // Keep both the current frame and the last published frame packed.  The
+    // allocation is bounded by MAX_STATE_BYTES and is checked before the
+    // device is attached to the HAL list.
+    _states = (uint8_t *)calloc((size_t)_stateByteCount * 2, 1);
+    if (!_states) {
+      DIAG(F("S88: unable to allocate %u bytes"),
+        (unsigned)(_stateByteCount * 2));
+      return;
+    }
+
+    _publishedStates = _states + _stateByteCount;
+    _hasCallback = true;
+    _ready = true;
+    IODevice::addDevice(this);
+  }
+
+  static bool validParameters(VPIN firstVpin, uint16_t nPins,
+                              uint8_t clockPin, uint8_t loadPin,
+                              uint8_t resetPin, uint8_t dataPin,
+                              uint32_t clockPeriodMicros) {
+    if (nPins == 0 || nPins > MAX_PINS)
+      return false;
+    if (firstVpin > VPIN_MAX ||
+        nPins > (uint16_t)(VPIN_MAX - firstVpin + 1))
+      return false;
+    if (clockPeriodMicros < MIN_CLOCK_PERIOD_MICROS ||
+        (clockPeriodMicros & 1))
+      return false;
+    if (clockPin == loadPin || clockPin == resetPin ||
+        clockPin == dataPin || loadPin == resetPin ||
+        loadPin == dataPin || resetPin == dataPin)
+      return false;
+#if defined(NUM_DIGITAL_PINS)
+    if (clockPin >= NUM_DIGITAL_PINS || loadPin >= NUM_DIGITAL_PINS ||
+        resetPin >= NUM_DIGITAL_PINS || dataPin >= NUM_DIGITAL_PINS)
+      return false;
+#endif
+    return true;
+  }
+
+  void _begin() override {
+    if (!_ready)
+      return;
+
+    pinMode(_clockPin, OUTPUT);
+    pinMode(_loadPin, OUTPUT);
+    pinMode(_resetPin, OUTPUT);
+    pinMode(_dataPin, _dataPullup ? INPUT_PULLUP : INPUT);
+
+    // S88 control signals are active high and idle low.
+    ArduinoPins::fastWriteDigital(_clockPin, LOW);
+    ArduinoPins::fastWriteDigital(_loadPin, LOW);
+    ArduinoPins::fastWriteDigital(_resetPin, LOW);
+
+    _deviceState = DEVSTATE_NORMAL;
+    _step = STEP_START;
+    _bitIndex = 0;
+    _publishIndex = 0;
+    _display();
+  }
+
+  bool _configure(VPIN vpin, ConfigTypeEnum configType,
+                  int paramCount, int params[]) override {
+    if (configType != CONFIGURE_INPUT || paramCount != 1 ||
+        !owns(vpin))
+      return false;
+
+    // Sensor pull-up configuration is meaningful only for the physical data
+    // line.  Accept it for compatibility with Sensor::create(), but keep the
+    // line configuration in one place.
+    _dataPullup = params[0] != 0;
+    pinMode(_dataPin, _dataPullup ? INPUT_PULLUP : INPUT);
+    return true;
+  }
+
+  int _read(VPIN vpin) override {
+    int index = (int)vpin - (int)_firstVpin;
+    if (index < 0 || index >= _nPins)
+      return 0;
+    return (_states[index >> 3] & (uint8_t)(1 << (index & 7))) ? 1 : 0;
+  }
+
+  void _loop(unsigned long currentMicros) override {
+    switch (_step) {
+    case STEP_START:
+      ArduinoPins::fastWriteDigital(_loadPin, HIGH);
+      _step = STEP_LOAD_CLOCK_HIGH;
+      schedule(currentMicros);
+      break;
+
+    case STEP_LOAD_CLOCK_HIGH:
+      // A clock edge while LOAD is asserted transfers the parallel input
+      // state into the shift registers used by the chain.
+      ArduinoPins::fastWriteDigital(_clockPin, HIGH);
+      _step = STEP_LOAD_CLOCK_LOW;
+      schedule(currentMicros);
+      break;
+
+    case STEP_LOAD_CLOCK_LOW:
+      ArduinoPins::fastWriteDigital(_clockPin, LOW);
+      _step = STEP_RELEASE_LOAD;
+      schedule(currentMicros);
+      break;
+
+    case STEP_RELEASE_LOAD:
+      ArduinoPins::fastWriteDigital(_loadPin, LOW);
+      _step = STEP_SAMPLE_FIRST;
+      schedule(currentMicros);
+      break;
+
+    case STEP_SAMPLE_FIRST:
+      // The first bit is present before the reset pulse.  Reset clears the
+      // upstream event latches ready for the next scan.
+      sampleBit(0);
+      _bitIndex = 1;
+      ArduinoPins::fastWriteDigital(_resetPin, HIGH);
+      _step = STEP_RELEASE_RESET;
+      schedule(currentMicros);
+      break;
+
+    case STEP_RELEASE_RESET:
+      ArduinoPins::fastWriteDigital(_resetPin, LOW);
+      if (_bitIndex >= _nPins)
+        _step = STEP_FINISH;
+      else
+        _step = STEP_CLOCK_HIGH;
+      schedule(currentMicros);
+      break;
+
+    case STEP_CLOCK_HIGH:
+      ArduinoPins::fastWriteDigital(_clockPin, HIGH);
+      _step = STEP_CLOCK_LOW;
+      schedule(currentMicros);
+      break;
+
+    case STEP_CLOCK_LOW:
+      ArduinoPins::fastWriteDigital(_clockPin, LOW);
+      _step = STEP_SAMPLE_CLOCKED;
+      schedule(currentMicros);
+      break;
+
+    case STEP_SAMPLE_CLOCKED:
+      // S88-N specifies that the data output changes on the falling clock
+      // edge.  Sampling after the low phase provides the required settling
+      // time even when the bus contains slower microcontroller modules.
+      sampleBit(_bitIndex);
+      _bitIndex++;
+      if (_bitIndex >= _nPins) {
+        _step = STEP_FINISH;
+        schedule(currentMicros);
+      } else {
+        ArduinoPins::fastWriteDigital(_clockPin, HIGH);
+        _step = STEP_CLOCK_LOW;
+        schedule(currentMicros);
+      }
+      break;
+
+    case STEP_FINISH:
+      _publishIndex = 0;
+      _step = STEP_PUBLISH;
+      delayUntil(currentMicros);
+      break;
+
+    case STEP_PUBLISH:
+      publishOne(currentMicros);
+      break;
+    }
+  }
+
+  void sampleBit(uint16_t index) {
+    bool value = ArduinoPins::fastReadDigital(_dataPin);
+    if (_invertData)
+      value = !value;
+
+    uint8_t mask = (uint8_t)(1 << (index & 7));
+    if (value)
+      _states[index >> 3] |= mask;
+    else
+      _states[index >> 3] &= (uint8_t)~mask;
+  }
+
+  void publishOne(unsigned long currentMicros) {
+    if (_publishIndex < _nPins) {
+      uint8_t mask = (uint8_t)(1 << (_publishIndex & 7));
+      uint8_t byteIndex = (uint8_t)(_publishIndex >> 3);
+      bool current = (_states[byteIndex] & mask) != 0;
+      bool previous = (_publishedStates[byteIndex] & mask) != 0;
+      if (current != previous) {
+        if (current)
+          _publishedStates[byteIndex] |= mask;
+        else
+          _publishedStates[byteIndex] &= (uint8_t)~mask;
+        if (IONotifyCallback::hasCallback())
+          IONotifyCallback::invokeAll(_firstVpin + _publishIndex,
+                                      current ? 1 : 0);
+      }
+      _publishIndex++;
+      delayUntil(currentMicros);
+      return;
+    }
+
+    _step = STEP_START;
+    delayUntil(currentMicros + _scanIntervalMicros);
+  }
+
+  void schedule(unsigned long currentMicros) {
+    delayUntil(currentMicros + _phaseMicros);
+  }
+
+  void _display() override {
+    DIAG(F("S88 configured on Vpins:%u-%u clock:%u load:%u reset:%u data:%u "
+            "period:%luus gap:%luus RAM:%uB"),
+         (unsigned)_firstVpin,
+         (unsigned)(_firstVpin + _nPins - 1),
+         (unsigned)_clockPin,
+         (unsigned)_loadPin,
+         (unsigned)_resetPin,
+         (unsigned)_dataPin,
+         (unsigned long)(_phaseMicros * 2),
+         (unsigned long)_scanIntervalMicros,
+         (unsigned)(_stateByteCount * 2));
+  }
+
+  uint8_t _clockPin;
+  uint8_t _loadPin;
+  uint8_t _resetPin;
+  uint8_t _dataPin;
+  unsigned long _phaseMicros;
+  unsigned long _scanIntervalMicros;
+  bool _invertData;
+  bool _dataPullup;
+  uint16_t _stateByteCount;
+  uint8_t *_states = NULL;
+  uint8_t *_publishedStates = NULL;
+  uint16_t _bitIndex = 0;
+  uint16_t _publishIndex = 0;
+  Step _step = STEP_START;
+  bool _ready = false;
+};
+
+#endif // IO_S88_H

--- a/IO_S88.h
+++ b/IO_S88.h
@@ -35,7 +35,7 @@ public:
     return (nPins + 7) / 8;
   }
 
-  static_assert(stateBytes(MAX_PINS) <= MAX_STATE_BYTES,
+  static_assert((MAX_PINS + 7) / 8 <= MAX_STATE_BYTES,
     "S88 state storage limit must cover the supported VPIN range");
 
   /*
@@ -236,7 +236,7 @@ private:
 
     case STEP_RELEASE_RESET:
       ArduinoPins::fastWriteDigital(_resetPin, LOW);
-      if (_bitIndex >= _nPins)
+      if (_bitIndex >= (uint16_t)_nPins)
         _step = STEP_FINISH;
       else
         _step = STEP_CLOCK_HIGH;
@@ -261,7 +261,7 @@ private:
       // time even when the bus contains slower microcontroller modules.
       sampleBit(_bitIndex);
       _bitIndex++;
-      if (_bitIndex >= _nPins) {
+      if (_bitIndex >= (uint16_t)_nPins) {
         _step = STEP_FINISH;
         schedule(currentMicros);
       } else {
@@ -296,7 +296,7 @@ private:
   }
 
   void publishOne(unsigned long currentMicros) {
-    if (_publishIndex < _nPins) {
+    if (_publishIndex < (uint16_t)_nPins) {
       uint8_t mask = (uint8_t)(1 << (_publishIndex & 7));
       uint8_t byteIndex = (uint8_t)(_publishIndex >> 3);
       bool current = (_states[byteIndex] & mask) != 0;

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Refer to [our web site](https://https://dcc-ex.com/ex-commandstation/get-started
 * Rename or copy ``config.example.h`` to ``config.h``. 
 * You must edit ``config.h`` according to the help texts in ``config.h``.
 
+## S88 and S88-N feedback
+
+CommandStation-EX can read one directly connected S88/S88-N chain as a HAL
+device.  Uncomment the S88 block in ``config.h`` and assign four unused,
+logic-compatible GPIO pins for CLOCK, LOAD, RESET, and DATA.  The chain's
+virtual pins can then be mapped to normal DCC-EX sensors with the ``<S ID
+VPIN PULLUP>`` command.  Multiple chains can be created with ``S88::create``
+from ``myHal.cpp`` or ``HAL(S88, ...)`` from EX-RAIL.
+
+The driver uses the normal cooperative HAL scheduler and does not claim a
+hardware timer.  Its default 200 microsecond clock period is intended as a
+safe starting point for mixed S88/S88-N chains; adjust it only after checking
+the timing requirements of every module in the chain.  The GPIO voltage,
+power supply, RJ45 pinout, level shifting, and common ground remain hardware
+responsibilities.  See [S88.md](S88.md) for the wiring and timing criteria.
+
 # More information
 You can learn more at the [DCC-EX website](https://dcc-ex.com/)
 

--- a/S88.md
+++ b/S88.md
@@ -1,0 +1,84 @@
+# S88 and S88-N feedback
+
+The S88 HAL driver reads a single serial S88 chain and exposes each shifted
+bit as a DCC-EX virtual input.  The first bit shifted from the chain is
+`firstVpin`; subsequent bits use consecutive virtual pins.
+
+## Configuration
+
+For one chain, uncomment and edit the S88 section in `config.h`:
+
+```cpp
+#define S88_FIRST_VPIN 300
+#define S88_NUM_PINS 128
+#define S88_CLOCK_PIN 26
+#define S88_LOAD_PIN 27
+#define S88_RESET_PIN 28
+#define S88_DATA_PIN 22
+#define S88_CLOCK_PERIOD_MICROS 200
+#define S88_SCAN_INTERVAL_MICROS 10000
+// #define S88_INVERT_DATA true
+// #define S88_DATA_PULLUP true
+```
+
+Then map the virtual inputs to DCC-EX sensors, for example:
+
+```text
+<S 1 300 0>
+<S 2 301 0>
+<E>
+```
+
+The same driver can be configured from `myHal.cpp`:
+
+```cpp
+#include "IO_S88.h"
+
+void halSetup() {
+  S88::create(300, 128, 26, 27, 28, 22, 200, 10000);
+}
+```
+
+Multiple chains need separate virtual-pin ranges and separate physical GPIO
+sets.  The EX-RAIL form is equivalent:
+
+```text
+HAL(S88, 300, 128, 26, 27, 28, 22, 200, 10000)
+```
+
+The driver accepts up to 255 inputs per chain.  It keeps two packed bitmaps,
+requiring `2 * ceil(inputs / 8)` bytes of RAM per chain (32 bytes for 128
+inputs and 64 bytes at the supported maximum).  It publishes at most one
+input change per HAL scheduler entry and does not install a timer interrupt.
+
+## Hardware criteria
+
+Before connecting a chain, verify all of the following:
+
+- The controller and every module share a suitable signal ground.
+- CLOCK, LOAD, RESET, and DATA are routed to four unused GPIOs.  Do not use a
+  GPIO already assigned to the motor shield, DCC waveform, serial interface,
+  or another HAL device.
+- The GPIO voltage thresholds are compatible with the modules.  Add a
+  direction-appropriate level translator when the chain is not electrically
+  compatible with the controller; this driver does not provide level shifting
+  or bus power.
+- For S88-N RJ45 wiring, verify the actual module pinout.  The common S88-N
+  allocation is RJ45 2 DATA, 3 and 5 GND, 4 CLOCK, 6 LOAD, 7 RESET, 1 bus
+  supply, and 8 optional RAILDATA.  Do not connect the bus supply directly to
+  a GPIO.
+- The selected clock period is acceptable to every module in the chain.  The
+  driver requires an even period of at least 30 microseconds, which gives
+  each high and low phase at least 15 microseconds.  Start at 200 microseconds
+  for mixed or unknown hardware; increase it if a module's documentation
+  requires slower timing.
+- Confirm whether the chain reports active inputs high or low.  Set
+  `S88_INVERT_DATA` to `true` for active-low hardware.
+
+The S88 bus has no addressing, parity, or checksum: a module's position in the
+chain determines its bit position.  Keep `S88_NUM_PINS` equal to the complete
+chain length and create only the sensor mappings that the application uses.
+
+The timing and S88-N pin criteria are based on the [S88-N timing guidance](https://s88-n.eu/en/s88-timing.html),
+[S88 protocol overview](https://s88-n.eu/en/s88-rj45.html), and the
+[S88-N pin allocation](https://s88-n.eu/en/).

--- a/S88_host_test.py
+++ b/S88_host_test.py
@@ -1,0 +1,68 @@
+"""Host-side regression checks for the platform-independent S88 HAL contract.
+
+The embedded project is compiled by PlatformIO in CI.  These checks run
+without an Arduino toolchain and protect the review-sensitive properties that
+can be verified from source: no timer-specific implementation, bounded packed
+state, compile-time configuration checks, and coverage of the supported CI
+targets.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+source = (ROOT / "IO_S88.h").read_text(encoding="utf-8")
+device = (ROOT / "IODevice.cpp").read_text(encoding="utf-8")
+platformio = (ROOT / "platformio.ini").read_text(encoding="utf-8")
+workflow = (ROOT / ".github" / "workflows" / "main.yml").read_text(encoding="utf-8")
+hardware = (ROOT / "S88.md").read_text(encoding="utf-8")
+exrail = (ROOT / "EXRAILMacros.h").read_text(encoding="utf-8")
+
+# The old contribution used an AVR Timer 5 ISR.  The HAL driver must remain
+# valid on megaAVR, Teensy, and other Arduino architectures.
+for forbidden in ("ISR(", "TCCR5", "TIMSK5", "OCR5A", "delayMicroseconds("):
+    require(forbidden not in source, f"S88 driver contains platform-specific {forbidden}")
+
+require("class S88 : public IODevice" in source, "S88 HAL class is missing")
+require("_hasCallback = true" in source, "S88 input callbacks are not enabled")
+require("IONotifyCallback::invokeAll" in source, "S88 changes are not published")
+require("static constexpr uint16_t stateBytes" in source, "S88 RAM sizing helper is missing")
+require("MAX_PINS = 255" in source, "S88 VPIN bound is not explicit")
+require("MAX_STATE_BYTES = 32" in source, "S88 packed-state bound is not explicit")
+
+
+def state_bytes(n_pins):
+    return (n_pins + 7) // 8
+
+
+require(state_bytes(128) * 2 == 32, "128-input S88 RAM expectation changed")
+require(state_bytes(255) * 2 == 64, "maximum S88 RAM expectation changed")
+
+require("S88_NUM_PINS" in device, "config.h S88 path is missing")
+for assertion in (
+    "S88_NUM_PINS <= S88::MAX_PINS",
+    "S88::stateBytes(S88_NUM_PINS) <= S88::MAX_STATE_BYTES",
+    "S88_CLOCK_PERIOD_MICROS >= S88::MIN_CLOCK_PERIOD_MICROS",
+    "S88_CLOCK_PIN != S88_LOAD_PIN",
+    "S88_CLOCK_PIN < NUM_DIGITAL_PINS",
+):
+    require(assertion in device, f"compile-time S88 check is missing: {assertion}")
+
+require("[env:mega2560-s88]" in platformio, "Mega S88 compile target is missing")
+require("[env:Teensy3_2-s88]" in platformio, "Teensy S88 compile target is missing")
+require("#define HAL(haltype,params...)  haltype::create(params);" in exrail,
+        "EX-RAIL HAL expansion is not available")
+require("HAL(S88," in hardware, "S88 EX-RAIL usage is not documented")
+require("platformio run -e mega2560-s88" in workflow, "Mega S88 CI step is missing")
+require("platformio run -e Teensy3_2-s88" in workflow, "Teensy S88 CI step is missing")
+for marker in ("CLOCK", "LOAD", "RESET", "DATA", "S88_INVERT_DATA", "S88_DATA_PULLUP"):
+    require(marker in hardware, f"hardware criteria omit {marker}")
+
+print("S88 host regression checks passed")

--- a/config.example.h
+++ b/config.example.h
@@ -369,3 +369,34 @@ The configuration file for DCC-EX Command Station
 // That is described further above.
 //
 /////////////////////////////////////////////////////////////////////////////////////
+
+//
+// S88 / S88-N FEEDBACK BUS
+//
+// Leave this block commented out unless a directly connected S88 chain is
+// wired to four unused, logic-compatible GPIO pins.  The driver is HAL-based
+// and does not use a hardware timer or an interrupt.  For multiple chains,
+// use S88::create() from myHal.cpp or HAL(S88, ...) from EX-RAIL instead.
+//
+// S88_FIRST_VPIN is the virtual pin for the first shifted bit.  Define one
+// Sensor for each virtual pin that should be reported to a throttle or JMRI.
+//
+// #define S88_FIRST_VPIN 300
+// #define S88_NUM_PINS 128
+// #define S88_CLOCK_PIN 26
+// #define S88_LOAD_PIN 27
+// #define S88_RESET_PIN 28
+// #define S88_DATA_PIN 22
+//
+// The clock period is the complete high + low period.  200us is a safe
+// starting point for mixed S88/S88-N chains; the value must be even and at
+// least 30us.  S88_SCAN_INTERVAL_MICROS is the idle gap after a full frame.
+// #define S88_CLOCK_PERIOD_MICROS 200
+// #define S88_SCAN_INTERVAL_MICROS 10000
+//
+// Most S88 modules report an active input as logic HIGH.  Set either option
+// to true only when the connected hardware requires it.
+// #define S88_INVERT_DATA false
+// #define S88_DATA_PULLUP false
+
+/////////////////////////////////////////////////////////////////////////////////////

--- a/platformio.ini
+++ b/platformio.ini
@@ -108,6 +108,24 @@ monitor_speed = 115200
 monitor_echo = yes
 build_flags = ${env.build_flags}
 
+; Compile-time coverage for the opt-in S88 HAL configuration.  The test
+; target uses the same Mega build as the normal environment, but enables a
+; representative 128-input chain through config macros.
+[env:mega2560-s88]
+extends = env:mega2560
+build_flags =
+	${env.build_flags}
+	-DS88_FIRST_VPIN=300
+	-DS88_NUM_PINS=128
+	-DS88_CLOCK_PIN=26
+	-DS88_LOAD_PIN=27
+	-DS88_RESET_PIN=28
+	-DS88_DATA_PIN=22
+	-DS88_CLOCK_PERIOD_MICROS=200
+	-DS88_SCAN_INTERVAL_MICROS=10000
+	-DS88_INVERT_DATA=0
+	-DS88_DATA_PULLUP=0
+
 [env:mega2560-eth]
 platform = atmelavr
 board = megaatmega2560
@@ -308,6 +326,24 @@ framework = arduino
 build_flags = -std=c++17  -Os -g2 ${env.build_flags}
 lib_deps = ${env.lib_deps}
 lib_ignore = NativeEthernet
+
+[env:Teensy3_2-s88]
+extends = env:Teensy3_2
+build_flags =
+	-std=c++17
+	-Os
+	-g2
+	${env.build_flags}
+	-DS88_FIRST_VPIN=300
+	-DS88_NUM_PINS=128
+	-DS88_CLOCK_PIN=10
+	-DS88_LOAD_PIN=11
+	-DS88_RESET_PIN=12
+	-DS88_DATA_PIN=13
+	-DS88_CLOCK_PERIOD_MICROS=200
+	-DS88_SCAN_INTERVAL_MICROS=10000
+	-DS88_INVERT_DATA=0
+	-DS88_DATA_PULLUP=0
 
 [env:Teensy3_5]
 platform = teensy


### PR DESCRIPTION
## Automatic issue closing

Fixes #249

## Summary

This PR addresses the S88 feedback request in [issue #249](https://github.com/DCC-EX/CommandStation-EX/issues/249) and refreshes the stale, non-mergeable [PR #166](https://github.com/DCC-EX/CommandStation-EX/pull/166). The earlier timer-specific design is not reused.

- Add a portable, cooperative S88/S88-N HAL input driver with configurable clock, load, reset, data polarity, and pull-up handling.
- Expose one-chain configuration macros plus `S88::create()` and EX-RAIL `HAL(S88, ...)` support.
- Bound each chain at 255 inputs with packed state storage and compile-time VPIN, timing, pin, and resource checks.
- Avoid hardware timers, interrupt handlers, blocking delays, and architecture-specific timer registers.
- Document S88-N wiring, level/power/ground requirements, timing criteria, bit ordering, and RAM impact.
- Add host regression checks and PlatformIO compile targets for the default AVR build, Mega 2560, and Teensy 3.2.

## Bounded scope

The change is limited to the S88 HAL, its IODevice registration/configuration path, example configuration, README and S88 hardware documentation, host regression checks, PlatformIO S88 targets, and the workflow steps that run those checks. The exact changed-file allowlist is:

- `.github/workflows/main.yml`
- `IODevice.cpp`
- `IODeviceList.h`
- `IO_S88.h`
- `README.md`
- `S88.md`
- `S88_host_test.py`
- `config.example.h`
- `platformio.ini`

Out of scope: unrelated device or protocol integrations, changes to the superseded timer/ISR approach, hardware level shifting or bus-power circuitry, files outside the allowlist, and physical hardware validation.

## Validation

- `S88_host_test.py` passed locally with the bundled Python runtime. It covers the no-timer/blocking contract, packed-state RAM bounds, compile-time configuration checks, EX-RAIL macro coverage, and Mega/Teensy target coverage.
- Python syntax/AST validation passed.
- `git diff --check upstream/master...HEAD` and `git diff --check HEAD` passed.
- Static scan found no `ISR(`, `TCCR5`, `TIMSK5`, `OCR5A`, or `delayMicroseconds(` references in `IO_S88.h`.
- Changed-path allowlist and generated/untracked-file checks passed.

## CI

[Fork Actions run 31947089326](https://github.com/BanjoR/CommandStation-EX/actions/runs/31947089326) completed successfully for commit `92353b342a8dbf7d17ca4407e1dd23f525d926f0`. The static regression, default AVR build, Mega S88 build, and Teensy S88 build all passed.

- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- The linked fork CI result remains additional evidence; no hardware/runtime result is implied.

- Historical fork run [31946900330](https://github.com/BanjoR/CommandStation-EX/actions/runs/31946900330) failed on superseded commit 8ed81194df4bbc8cc2a0f333a48d2368dfef428d at the IO_S88.h compile-time assertion; the current head and run above are the corrected result.

## Hardware validation

Hardware validation: Not run—no hardware available.

Maintainer bench criteria:

1. Connect representative S88 and S88-N modules with verified common ground, compatible GPIO voltage levels, correct RJ45 pin allocation, and appropriate level shifting. Do not connect bus supply to a GPIO.
2. Capture LOAD, CLOCK, RESET, and DATA with a logic analyzer. Verify the documented sequence, data bit order, an even clock period of at least 30 microseconds with at least 15 microseconds per phase, and the default 200-microsecond starting configuration.
3. Toggle first, middle, and last inputs through the complete chain and verify the corresponding virtual-pin readings and callbacks, including active-low and pull-up configurations.
4. Repeat with the longest intended chain and cable length while checking power/ground stability and coexistence with DCC waveform activity.

See [`S88.md`](https://github.com/BanjoR/CommandStation-EX/blob/92353b342a8dbf7d17ca4407e1dd23f525d926f0/S88.md) for the wiring and timing criteria.