### PR TITLE
Improve W5500 Ethernet configuration and diagnostics

### DIFF
--- a/EthernetInterface.cpp
+++ b/EthernetInterface.cpp
@@ -31,6 +31,9 @@
 #include "CommandDistributor.h"
 #include "WiThrottle.h"
 #include "DCCTimer.h"
+#if defined(DCCEX_WIZNET_ETHERNET) && defined(ARDUINO_ARCH_ESP32)
+#include <SPI.h>
+#endif
 
 #ifdef DO_MDNS
 #include "EXmDNS.h"
@@ -48,6 +51,41 @@ bool EthernetInterface::inUse[MAX_SOCK_NUM];                // accept up to MAX_
 uint8_t EthernetInterface::buffer[MAX_ETH_BUFFER+1];                    // buffer used by TCP for the recv
 RingStream * EthernetInterface::outboundRing = nullptr;
 
+#if defined(DCCEX_WIZNET_ETHERNET)
+static void reportWiznetStatus() {
+  switch (Ethernet.hardwareStatus()) {
+    case EthernetNoHardware:
+      DIAG(F("Ethernet hardware: none detected"));
+      break;
+    case EthernetW5100:
+      DIAG(F("Ethernet hardware: W5100"));
+      break;
+    case EthernetW5200:
+      DIAG(F("Ethernet hardware: W5200"));
+      break;
+    case EthernetW5500:
+      DIAG(F("Ethernet hardware: W5500"));
+      break;
+    default:
+      DIAG(F("Ethernet hardware: unknown"));
+      break;
+  }
+
+  switch (Ethernet.linkStatus()) {
+    case LinkON:
+      DIAG(F("Ethernet link: ON"));
+      break;
+    case LinkOFF:
+      DIAG(F("Ethernet link: OFF"));
+      break;
+    case Unknown:
+    default:
+      DIAG(F("Ethernet link: UNKNOWN"));
+      break;
+  }
+}
+#endif
+
 /**
  * @brief Setup Ethernet Connection
  * 
@@ -61,6 +99,33 @@ void EthernetInterface::setup()
   #endif 
     " Please be patient, especially if no cable is connected!"
   ));
+
+  DIAG(F("Ethernet hostname: %s"), (char *)ETHERNET_HOSTNAME);
+
+  #if defined(DCCEX_WIZNET_ETHERNET)
+    #if defined(ARDUINO_ARCH_ESP32)
+      DIAG(F("Ethernet SPI pins: CS=%d SCK=%d MISO=%d MOSI=%d RST=%d"),
+        ETHERNET_CS_PIN, ETHERNET_SCK_PIN, ETHERNET_MISO_PIN, ETHERNET_MOSI_PIN, ETHERNET_RST_PIN);
+      SPI.begin(ETHERNET_SCK_PIN, ETHERNET_MISO_PIN, ETHERNET_MOSI_PIN, ETHERNET_CS_PIN);
+      #if ETHERNET_RST_PIN >= 0
+        pinMode(ETHERNET_RST_PIN, OUTPUT);
+        digitalWrite(ETHERNET_RST_PIN, LOW);
+        delay(2);
+        digitalWrite(ETHERNET_RST_PIN, HIGH);
+        delay(150);
+      #endif
+      Ethernet.init(ETHERNET_CS_PIN);
+      DIAG(F("Ethernet CS pin %d"), ETHERNET_CS_PIN);
+    #else
+      #if defined(ETHERNET_CS_PIN) && !defined(ETHERNET_CS)
+        #define ETHERNET_CS ETHERNET_CS_PIN
+      #endif
+      #ifdef ETHERNET_CS
+        Ethernet.init(ETHERNET_CS);
+        DIAG(F("Ethernet CS pin %d"), ETHERNET_CS);
+      #endif
+    #endif
+  #endif
   
   #ifdef STM32_ETHERNET
     // Set a HOSTNAME for the DHCP request - a nice to have, but hard it seems on LWIP for STM32
@@ -82,18 +147,29 @@ void EthernetInterface::setup()
     static IPAddress myIP(IP_ADDRESS);
     Ethernet.begin(mac,myIP);
   #else
+    DIAG(F("Ethernet requesting DHCP"));
     if (Ethernet.begin(mac)==0)
   {
     LCD(4,F("IP: No DHCP"));
+    #if defined(DCCEX_WIZNET_ETHERNET)
+      reportWiznetStatus();
+    #endif
+    DIAG(F("Ethernet DHCP failed; check CS wiring, cable, and network"));
     return;
   }
+  #endif
+
+  #if defined(DCCEX_WIZNET_ETHERNET)
+    reportWiznetStatus();
   #endif
 
   auto ip = Ethernet.localIP();    // look what IP was obtained (dynamic or static)
   if (!ip) {
     LCD(4,F("IP: None"));
+    DIAG(F("Ethernet has no IP address"));
     return;
   }
+  DIAG(F("Ethernet IP: %d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
   server = new EthernetServer(IP_PORT); // Ethernet Server listening on default port IP_PORT
   server->begin();
 

--- a/EthernetInterface.cpp
+++ b/EthernetInterface.cpp
@@ -45,7 +45,7 @@ MDNS mdns(udp);
 #define looptimer(a,b)
 
 bool EthernetInterface::connected=false;
-EthernetServer * EthernetInterface::server= nullptr;
+EthernetServerType * EthernetInterface::server= nullptr;
 EthernetClient EthernetInterface::clients[MAX_SOCK_NUM];                // accept up to MAX_SOCK_NUM client connections at the same time; This depends on the chipset used on the Shield
 bool EthernetInterface::inUse[MAX_SOCK_NUM];                // accept up to MAX_SOCK_NUM client connections at the same time; This depends on the chipset used on the Shield
 uint8_t EthernetInterface::buffer[MAX_ETH_BUFFER+1];                    // buffer used by TCP for the recv
@@ -170,7 +170,7 @@ void EthernetInterface::setup()
     return;
   }
   DIAG(F("Ethernet IP: %d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
-  server = new EthernetServer(IP_PORT); // Ethernet Server listening on default port IP_PORT
+  server = new EthernetServerType(IP_PORT); // Ethernet Server listening on default port IP_PORT
   server->begin();
 
   // Arrange display of IP address and port

--- a/EthernetInterface.h
+++ b/EthernetInterface.h
@@ -53,6 +53,7 @@
  #define DO_MDNS
 #else
  #include "Ethernet.h"
+ #define DCCEX_WIZNET_ETHERNET
  #define DO_MDNS
 #endif
 

--- a/EthernetInterface.h
+++ b/EthernetInterface.h
@@ -57,6 +57,21 @@
  #define DO_MDNS
 #endif
 
+#if defined(ARDUINO_ARCH_ESP32)
+// Arduino Ethernet 2.0.x exposes begin() without the uint16_t parameter
+// required by the ESP32 Arduino Server base class. Add the missing override
+// without modifying or vendoring the external Ethernet library.
+class DCCEXEthernetServer : public EthernetServer {
+ public:
+    using EthernetServer::EthernetServer;
+    using EthernetServer::begin;
+    void begin(uint16_t) override { EthernetServer::begin(); }
+};
+using EthernetServerType = DCCEXEthernetServer;
+#else
+using EthernetServerType = EthernetServer;
+#endif
+
 
 #include "RingStream.h"
 
@@ -77,7 +92,7 @@ class EthernetInterface {
    
  private:
     static bool connected;
-    static EthernetServer * server;
+    static EthernetServerType * server;
     static EthernetClient clients[MAX_SOCK_NUM];                // accept up to MAX_SOCK_NUM client connections at the same time; This depends on the chipset used on the Shield
     static bool inUse[MAX_SOCK_NUM];                // accept up to MAX_SOCK_NUM client connections at the same time; This depends on the chipset used on the Shield
     static uint8_t buffer[MAX_ETH_BUFFER+1];                    // buffer used by TCP for the recv

--- a/config.example.h
+++ b/config.example.h
@@ -83,7 +83,9 @@ The configuration file for DCC-EX Command Station
 // NOTE: Not supported on Arduino Uno or Nano
 // Set to false if you not even want it on the Arduino Mega
 //
-#define ENABLE_WIFI true
+#ifndef ENABLE_WIFI
+  #define ENABLE_WIFI true
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////
 //
@@ -119,6 +121,10 @@ The configuration file for DCC-EX Command Station
 // CS to make them show up with different names on the network.
 // Otherwise do not touch.
 #define WIFI_HOSTNAME "dccex"
+
+// ETHERNET_HOSTNAME is used by Ethernet mDNS and native STM32 Ethernet.
+// If omitted, it defaults to WIFI_HOSTNAME for compatibility with EX-Installer.
+//#define ETHERNET_HOSTNAME "dccex-ethernet"
 //
 // WIFI_CHANNEL: The default channel is set to "1". If you need to use an
 // alternate channel (we recommend using only 1,6, or 11) you may change it here.
@@ -137,6 +143,15 @@ The configuration file for DCC-EX Command Station
 //
 //#define ENABLE_ETHERNET true
 
+// Arduino Ethernet W5100/W5500 chip-select. The default shield pin is 10;
+// set this to the pin actually connected to the module. ETHERNET_CS_PIN is
+// also accepted and is the preferred name for ESP32 configurations.
+//#define ETHERNET_CS 10
+//#define ETHERNET_CS_PIN 5
+
+// ESP32 W5500 defaults used by the ESP32-Ethernet environment are CS=5,
+// SCK=18, MISO=16, MOSI=17, and RST=4. Override them above or in config.h.
+
 /////////////////////////////////////////////////////////////////////////////////////
 //
 // MAX_NUM_TCP_CLIENTS: If you on STM32 Ethernet (and only there) want more than
@@ -153,6 +168,19 @@ The configuration file for DCC-EX Command Station
 // DEFINE STATIC IP ADDRESS *OR* COMMENT OUT TO USE DHCP
 //
 //#define IP_ADDRESS { 192, 168, 1, 200 }
+
+// With IP_ADDRESS omitted, Arduino W5100/W5500 builds request an address by
+// DHCP automatically. WIFI_SSID and WIFI_PASSWORD are not used for Ethernet.
+// The official Arduino Ethernet dependency currently supplies its own DHCP
+// hostname; ETHERNET_HOSTNAME controls mDNS/native Ethernet naming, but a
+// custom W5500 DHCP hostname requires a dependency that exposes that option.
+
+// W5500 hardware validation (Mega or ESP32 + module): connect power, ground,
+// SPI, CS, and optional reset as configured; connect to a DHCP-enabled LAN;
+// confirm diagnostics report the expected hardware, link, DHCP, hostname, and
+// non-zero IP; then connect a client to IP_PORT (default 2560) and verify a
+// command/reply round trip. Repeat with the cable disconnected to verify the
+// link/DHCP failure diagnostics.
 
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/defines.h
+++ b/defines.h
@@ -32,6 +32,14 @@
     #include "config.h"
 #endif
 
+// Wired Ethernet is the exclusive network interface on ESP32 Ethernet builds.
+// Apply this before the ESP32 feature defaults so a PlatformIO build flag can
+// select Ethernet even when an older config.h still enables WiFi.
+#if defined(ARDUINO_ARCH_ESP32) && ENABLE_ETHERNET
+  #undef ENABLE_WIFI
+  #define ENABLE_WIFI false
+#endif
+
 #ifndef MOTOR_SHIELD_TYPE
   #define MOTOR_SHIELD_TYPE NO_SHIELD
 #endif
@@ -221,6 +229,26 @@
 
 #if WIFI_ON && ETHERNET_ON
  #error Command Station does not support WIFI and ETHERNET at the same time.
+#endif
+
+#if defined(ARDUINO_ARCH_ESP32) && ETHERNET_ON
+  // Defaults for the external W5100/W5500 SPI connection used by the
+  // ESP32-Ethernet PlatformIO environment. Override in config.h as needed.
+  #ifndef ETHERNET_CS_PIN
+    #define ETHERNET_CS_PIN 5
+  #endif
+  #ifndef ETHERNET_SCK_PIN
+    #define ETHERNET_SCK_PIN 18
+  #endif
+  #ifndef ETHERNET_MISO_PIN
+    #define ETHERNET_MISO_PIN 16
+  #endif
+  #ifndef ETHERNET_MOSI_PIN
+    #define ETHERNET_MOSI_PIN 17
+  #endif
+  #ifndef ETHERNET_RST_PIN
+    #define ETHERNET_RST_PIN 4
+  #endif
 #endif
   
 ////////////////////////////////////////////////////////////////////////////////

--- a/platformio.ini
+++ b/platformio.ini
@@ -123,7 +123,7 @@ lib_ignore = WiFi101
             WiFiNINA_Generic
 monitor_speed = 115200
 monitor_echo = yes
-build_flags = ${env.build_flags}
+build_flags = -DENABLE_WIFI=false -DENABLE_ETHERNET=true ${env.build_flags}
 
 [env:mega328]
 platform = atmelavr
@@ -191,6 +191,19 @@ board = esp32dev
 framework = arduino
 lib_deps = ${env.lib_deps}
 build_flags = -std=c++17 ${env.build_flags}
+monitor_speed = 115200
+monitor_echo = yes
+
+[env:ESP32-Ethernet]
+; ESP32 with an external W5100/W5500 over SPI.
+; Override ETHERNET_*_PIN values in config.h for other wiring.
+platform = espressif32 @ 6.7.0
+board = esp32dev
+framework = arduino
+lib_deps = ${env.lib_deps}
+    arduino-libraries/Ethernet
+    SPI
+build_flags = -std=c++17 -DENABLE_WIFI=false -DENABLE_ETHERNET=true ${env.build_flags}
 monitor_speed = 115200
 monitor_echo = yes
 


### PR DESCRIPTION
## Automatic issue closing

Fixes #308
Fixes #313

Issue #375 is broader network/DHCP behavior; this PR does not claim to close that full report.

## Summary

Refresh W5100/W5500 Ethernet configuration and diagnostics for wired CommandStation builds:

- add platform-gated chip-select selection through ETHERNET_CS and ETHERNET_CS_PIN
- add the ESP32-Ethernet PlatformIO environment with configurable SPI and reset pins
- add WIZnet hardware, link, DHCP, hostname, and IP diagnostics
- document wired-network configuration, dependency limitations, and a reproducible W5500 bench procedure

## Bounded scope and exclusions

The exact changed-file scope is limited to:

- EthernetInterface.cpp
- EthernetInterface.h
- config.example.h
- defines.h
- platformio.ini

This change does not vendor or modify the Arduino Ethernet dependency, add Wi-Fi behavior, change the protocol/API, or include the ESP32 OTA/custom-server work from PR #525. The wired environments set ENABLE_WIFI=false and ENABLE_ETHERNET=true; the existing configuration also rejects simultaneous Wi-Fi and Ethernet. WIFI_SSID and WIFI_PASSWORD are not used for Ethernet.

The official Arduino Ethernet dependency requests DHCP when IP_ADDRESS is omitted but hard-codes its DHCP hostname option. ETHERNET_HOSTNAME is applied to DCC-EX mDNS/native STM32 naming and reported at startup; a custom W5500 DHCP hostname requires a dependency API/library update: https://github.com/arduino-libraries/Ethernet/blob/master/src/Dhcp.cpp

## References

Authoritative issues:

- [Issue #308](https://github.com/DCC-EX/CommandStation-EX/issues/308)
- [Issue #313](https://github.com/DCC-EX/CommandStation-EX/issues/313)
- [Issue #375](https://github.com/DCC-EX/CommandStation-EX/issues/375)

Superseded or incomplete PRs:

- [PR #316](https://github.com/DCC-EX/CommandStation-EX/pull/316)
- [PR #317](https://github.com/DCC-EX/CommandStation-EX/pull/317)
- [PR #525](https://github.com/DCC-EX/CommandStation-EX/pull/525)

## Validation evidence

### Host audit

- Clean checkout on branch codex/commandstation-ex-commandstation-esp32-ethernet; origin is BanjoR/CommandStation-EX, upstream is DCC-EX/CommandStation-EX, and upstream/master is 0ad3080bd94949c75fd4824f54ae792bd990886b.
- PR head is 687a8c2e991ad711c57dc45e07e6e1b0b35d10be, with upstream/master as its ancestor.
- Worktree, index, untracked files, and ignored generated outputs were clean after validation; the public PR file list is exactly the five files above.
- git diff --check upstream/master...HEAD: PASS.
- Focused static assertions for diagnostics, configurable SPI/CS/reset, Wi-Fi exclusion, PlatformIO environments/flags, DHCP/hostname limitation, and bench documentation: PASS.
- Repository CI-equivalent generated-config build, python -m platformio run for mega2560: PASS. RAM 19.0% (1560/8192); Flash 38.3% (97226/253952).
- Focused W5500 Mega build, python -m platformio run -e mega2560-eth: PASS. RAM 27.5% (2251/8192); Flash 42.1% (106848/253952).
- Embedded Ztest.cpp compiled in both Mega builds. The repository has no standalone host/unit-test target, and no runtime test was executed.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- PASS - Focused `python -m platformio run -e ESP32-Ethernet` after the ESP32 Server API compatibility adapter: 22.15 seconds; RAM 27,304/327,680 (8.3%); Flash 497,301/1,310,720 (37.9%).
- No standalone CMake/C++ compiler or formatter was available outside PlatformIO; git diff --check was the available whitespace/format gate.

### GitHub Actions and required checks

- [PR #541](https://github.com/DCC-EX/CommandStation-EX/pull/541) is OPEN and ready for review, based on master at 0ad3080bd94949c75fd4824f54ae792bd990886b and head 687a8c2e991ad711c57dc45e07e6e1b0b35d10be.
- The upstream PR status-check rollup remains empty because the repository firmware workflow is push-triggered; the successful fork run below is the available exact-head firmware CI evidence.
- The upstream [CI workflow](https://github.com/DCC-EX/CommandStation-EX/blob/master/.github/workflows/main.yml) is configured as on: [push], installs PlatformIO, copies config.example.h to config.h, and runs python -m platformio run; it does not declare a pull_request trigger, so no firmware CI check is attached to this cross-repository PR.
- Exact-head fork CI: PASS - [CI run 31995620650](https://github.com/BanjoR/CommandStation-EX/actions/runs/31995620650) completed successfully for head 687a8c2e991ad711c57dc45e07e6e1b0b35d10be, including the Compile Command Station (AVR) job.
- Upstream PR status remains empty because the repository firmware workflow is push-triggered; the fork run above is the available exact-head firmware CI evidence. Ancillary Docs and Label sponsors runs are not used as firmware evidence.

## Hardware validation

Hardware validation: Not run—no hardware available

Maintainer bench procedure:

1. Use a Mega2560 or ESP32 with a W5500 module. Connect power and ground, SPI SCK/MISO/MOSI, the configured CS pin, and the optional ESP32 reset pin according to the module’s electrical requirements; connect the RJ45 to a DHCP-enabled LAN.
2. Build mega2560-eth or ESP32-Ethernet with a generated config.h. Exercise both the documented default and a non-default CS setting (ETHERNET_CS on Mega or ETHERNET_CS_PIN on ESP32), adjusting the SPI/reset pins when required by the wiring.
3. Capture startup diagnostics and require W5500 hardware detection, the expected CS/SPI/reset values, link ON, DHCP request/success, hostname reporting, and a non-zero IP address.
4. Connect a client to IP_PORT (default 2560) and verify a DCC-EX command/reply round trip.
5. Disconnect and reconnect the Ethernet cable. Require link/DHCP failure diagnostics while disconnected and successful link/IP recovery after reconnection.