### PR TITLE
Add configurable signal aspect maps

### DIFF
--- a/EXRAIL2.cpp
+++ b/EXRAIL2.cpp
@@ -1446,31 +1446,34 @@ case sigtypeNEOPIXEL:
   
   case sigtypeSIGNAL:
   case sigtypeSIGNALH:
+  case sigtypeSIGNALA:
+  case sigtypeSIGNALAH:
   {
   // LED or similar 3 pin signal, (all pins zero would be a virtual signal)
   // If amberpin is zero, synthesise amber from red+green
-  const byte SIMAMBER=0x00;
-  if (rag==SIGNAL_AMBER && (signal.amberpin==0)) rag=SIMAMBER; // special case this func only
+  byte aspect=(signal.type==sigtypeSIGNALA || signal.type==sigtypeSIGNALAH)
+                ? SIGNAL_ALT_ASPECT : SIGNAL_MAIN_ASPECT;
+  if (signal.redpin && signal.greenpin && !signal.amberpin)
+    aspect=(aspect & 0707) | ((aspect & 0700)>>3) | ((aspect & 07)<<3);
+  bool aHigh=signal.type==sigtypeSIGNALH || signal.type==sigtypeSIGNALAH;
+  byte pinmap=rag==SIGNAL_RED ? (aspect>>6) : rag==SIGNAL_AMBER ? ((aspect>>3)&07) : (aspect&07);
+  if (rag==SIGNAL_AMBER && !signal.amberpin) pinmap=((aspect>>6)&07)|(aspect&07);
    
   // Manage invert (HIGH on) pins
-  bool aHigh=signal.type==sigtypeSIGNALH;
       
   // set the three pins 
   if (signal.redpin) {
-    bool redval=(rag==SIGNAL_RED || rag==SIMAMBER);
-    if (!aHigh) redval=!redval;
+    bool redval=(pinmap & 04) != 0; if (!aHigh) redval=!redval;
     killBlinkOnVpin(signal.redpin);
     IODevice::write(signal.redpin,redval);
   }
   if (signal.amberpin) {
-    bool amberval=(rag==SIGNAL_AMBER);
-    if (!aHigh) amberval=!amberval;
+    bool amberval=(pinmap & 02) != 0; if (!aHigh) amberval=!amberval;
     killBlinkOnVpin(signal.amberpin);
     IODevice::write(signal.amberpin,amberval);
   }
   if (signal.greenpin) {
-    bool greenval=(rag==SIGNAL_GREEN || rag==SIMAMBER);
-    if (!aHigh) greenval=!greenval;
+    bool greenval=(pinmap & 01) != 0; if (!aHigh) greenval=!greenval;
     killBlinkOnVpin(signal.greenpin);
     IODevice::write(signal.greenpin,greenval);
   }

--- a/EXRAIL2.h
+++ b/EXRAIL2.h
@@ -134,6 +134,8 @@ enum SignalType {
        sigtypeVIRTUAL,
        sigtypeSIGNAL, 
        sigtypeSIGNALH, 
+       sigtypeSIGNALA,
+       sigtypeSIGNALAH,
        sigtypeDCC,
        sigtypeDCCX,
        sigtypeSERVO,
@@ -147,6 +149,12 @@ enum SignalType {
        VPIN id;  
        VPIN  redpin,amberpin,greenpin; 
   };
+#ifndef SIGNAL_MAIN_ASPECT
+#define SIGNAL_MAIN_ASPECT 0421
+#endif
+#ifndef SIGNAL_ALT_ASPECT
+#define SIGNAL_ALT_ASPECT 0431
+#endif
 
   // Flag bits for compile time features.
   static const byte FEATURE_SIGNAL= 0x80;

--- a/EXRAIL2MacroBase.h
+++ b/EXRAIL2MacroBase.h
@@ -781,6 +781,10 @@
 ///param redpin vpin for RED state, also acts as signal_id
 
 #define SIGNALH(redpin,amberpin,greenpin)
+///\brief Define a signal using the alternate aspect map, LOW=on
+#define SIGNALA(redpin,amberpin,greenpin)
+///\brief Define a signal using the alternate aspect map, HIGH=on
+#define SIGNALAH(redpin,amberpin,greenpin)
 ///brief define a signal with HIGH=ON leds
 ///param redpin vpin for RED state, also acts as signal_id
 

--- a/EXRAIL2MacroReset.h
+++ b/EXRAIL2MacroReset.h
@@ -207,6 +207,8 @@
 #undef SETFREQ
 #undef SIGNAL 
 #undef SIGNALH 
+#undef SIGNALA
+#undef SIGNALAH
 #undef SPEED
 #undef SPEEDUP
 #undef SPEED_REL

--- a/EXRAILAsserts.h
+++ b/EXRAILAsserts.h
@@ -181,6 +181,10 @@ constexpr bool unsafePin(const int16_t value, const int16_t pos=0 ) {
       static_assert(!unsafePin(redpin),"Red pin " #redpin _PIN_RESERVED_); \
       static_assert(amberpin==0 ||!unsafePin(amberpin),"Amber pin " #amberpin _PIN_RESERVED_); \
       static_assert(!unsafePin(greenpin),"Green pin " #greenpin _PIN_RESERVED_); 
+#undef SIGNALA
+#define SIGNALA(redpin,amberpin,greenpin) SIGNAL(redpin,amberpin,greenpin)
+#undef SIGNALAH
+#define SIGNALAH(redpin,amberpin,greenpin) SIGNALH(redpin,amberpin,greenpin)
 
 // and run the assert pass.       
 #include "myAutomation.h"

--- a/EXRAILMacros.h
+++ b/EXRAILMacros.h
@@ -172,6 +172,10 @@ void exrailHalSetup2() {
 #define SIGNAL(redpin,amberpin,greenpin) | FEATURE_SIGNAL 
 #undef SIGNALH
 #define SIGNALH(redpin,amberpin,greenpin) | FEATURE_SIGNAL 
+#undef SIGNALA
+#define SIGNALA(redpin,amberpin,greenpin) | FEATURE_SIGNAL
+#undef SIGNALAH
+#define SIGNALAH(redpin,amberpin,greenpin) | FEATURE_SIGNAL
 #undef SERVO_SIGNAL
 #define SERVO_SIGNAL(vpin,redval,amberval,greenval) | FEATURE_SIGNAL 
 #undef DCC_SIGNAL
@@ -473,6 +477,10 @@ const FSH * RMFT2::getRosterFunctions(int16_t id) {
 #define SIGNAL(redpin,amberpin,greenpin) {sigtypeSIGNAL,redpin,redpin,amberpin,greenpin}, 
 #undef SIGNALH
 #define SIGNALH(redpin,amberpin,greenpin) {sigtypeSIGNALH,redpin,redpin,amberpin,greenpin}, 
+#undef SIGNALA
+#define SIGNALA(redpin,amberpin,greenpin) {sigtypeSIGNALA,redpin,redpin,amberpin,greenpin},
+#undef SIGNALAH
+#define SIGNALAH(redpin,amberpin,greenpin) {sigtypeSIGNALAH,redpin,redpin,amberpin,greenpin},
 #undef SERVO_SIGNAL
 #define SERVO_SIGNAL(vpin,redval,amberval,greenval) {sigtypeSERVO,vpin,redval,amberval,greenval}, 
 #undef DCC_SIGNAL
@@ -722,6 +730,8 @@ int RMFT2::onLCCLookup[RMFT2::countLCCLookup];
 #define SETFREQ(freq) OPCODE_SETFREQ,V(freq),
 #define SIGNAL(redpin,amberpin,greenpin) 
 #define SIGNALH(redpin,amberpin,greenpin) 
+#define SIGNALA(redpin,amberpin,greenpin)
+#define SIGNALAH(redpin,amberpin,greenpin)
 #define SPEED(speed) OPCODE_SPEED,V(speed),
 #define SPEEDUP(speedstep) OPCODE_SPEEDUP,V(speedstep),
 #define SPEED_REL(percent) OPCODE_SPEED_REL,V(percent),

--- a/config.example.h
+++ b/config.example.h
@@ -29,6 +29,12 @@ The configuration file for DCC-EX Command Station
 **********************************************************************/
 
 /////////////////////////////////////////////////////////////////////////////////////
+#ifndef SIGNAL_MAIN_ASPECT
+// Three-bit octal pin maps for RED, AMBER and GREEN. The defaults preserve the
+// historical one-pin-per-aspect behavior; SIGNALA/SIGNALAH use the alternate map.
+#define SIGNAL_MAIN_ASPECT 0421
+#define SIGNAL_ALT_ASPECT 0431
+#endif
 // If you want to add your own motor driver definition(s), add them here
 //   For example MY_SHIELD with display name "MINE":
 //   (remove comment start and end marker if you want to edit and use that)

--- a/test/signal_aspects.py
+++ b/test/signal_aspects.py
@@ -1,0 +1,41 @@
+"""Host regression tests for the CommandStation signal aspect-map contract."""
+
+MAIN = 0o421
+ALT = 0o431
+
+
+def pin_map(aspect, state, has_amber=True):
+    if not has_amber and state == "amber":
+        return ((aspect >> 6) & 0o7) | (aspect & 0o7)
+    return {"red": aspect >> 6, "amber": (aspect >> 3) & 0o7, "green": aspect & 0o7}[state]
+
+
+def output(aspect, state, active_high, has_amber=True):
+    mask = pin_map(aspect, state, has_amber)
+    values = [(mask & bit) != 0 for bit in (0o4, 0o2, 0o1)]
+    return values if active_high else [not value for value in values]
+
+
+def test_main_map_preserves_legacy_low_active_signal():
+    assert output(MAIN, "red", False) == [False, True, True]
+    assert output(MAIN, "amber", False) == [True, False, True]
+    assert output(MAIN, "green", False) == [True, True, False]
+
+
+def test_high_active_signal_is_the_polarity_inverse():
+    assert output(MAIN, "red", True) == [True, False, False]
+
+
+def test_alternate_map_can_light_red_and_green_for_amber():
+    assert output(ALT, "amber", True) == [False, True, True]
+
+
+def test_missing_amber_pin_synthesizes_red_and_green():
+    assert output(MAIN, "amber", True, has_amber=False) == [True, False, True]
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in globals().items() if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"{len(tests)} signal aspect tests passed")


### PR DESCRIPTION
## Scope

This PR is limited to the CommandStation/HAL side of signal aspect mapping and signal state handling.

In scope:

- Preserve the existing `SIGNAL` and `SIGNALH` automation behavior and polarity.
- Add `SIGNALA` and `SIGNALAH` automation definitions for an alternate three-LED aspect map.
- Support configurable main/alternate octal aspect maps through `config.h`.
- Preserve synthesized amber behavior when a signal has red and green pins but no physical amber pin.
- Update the corresponding EXRAIL macro, reset, assertion, and signal-definition passes.

Explicitly out of scope:

- DCCEXProtocol changes, protocol serialization, or client-facing aspect contracts; those belong in the separate sibling task.
- Personal integration code and unrelated protocol behavior are explicitly out of scope.
- A generalized four-aspect HAL-device rearchitecture or physical hardware integration.

## Authoritative references

- [Issue #422 — Different styles of signal aspects](https://github.com/DCC-EX/CommandStation-EX/issues/422)
- [Issue #473 — White signal aspect](https://github.com/DCC-EX/CommandStation-EX/issues/473)
- [Issue #463 — Reengineer Signals as HAL type devices](https://github.com/DCC-EX/CommandStation-EX/issues/463)
- [Superseded upstream PR #423](https://github.com/DCC-EX/CommandStation-EX/pull/423), inspected as the prior aspect-map proposal
- [Superseded fork-only PR #9](https://github.com/BanjoR/CommandStation-EX/pull/9)

This PR is intentionally a bounded HAL/CommandStation refresh and does not claim to complete the protocol or broader HAL redesign work described by the linked issues.

## Compatibility

Existing `SIGNAL` and `SIGNALH` automations remain source-compatible. Their historical active-low/active-high behavior is preserved. `SIGNALA` and `SIGNALAH` are additive automation definitions and require the separate DCCEXProtocol work before any protocol consumer can rely on a new serialized aspect contract.

## Verification evidence

Passed locally in the isolated task checkout:

- Focused host regression: `python test/signal_aspects.py` — **4 signal aspect tests passed**. [Test source](https://github.com/BanjoR/CommandStation-EX/blob/a9dd06e49e66be3e86acf1560be05028d22abf69/test/signal_aspects.py)
- No-write Python AST syntax parse — **passed**.
- `git diff --check` against `upstream/master` — **passed**.
- Clean worktree, upstream ancestry, remotes, and changed-file allowlist — **passed** in the task checkout.
- Repository unittest discovery — **no unittest suite found; 0 tests ran**.

GitHub/CI evidence:

- [Upstream PR checks](https://github.com/DCC-EX/CommandStation-EX/pull/543/checks) — no checks reported at audit time.
- [Repository CI workflow](https://github.com/DCC-EX/CommandStation-EX/actions/workflows/main.yml) — no completed build result for this PR.
- [Docs workflow run](https://github.com/DCC-EX/CommandStation-EX/actions/runs/31947137966) — `action_required`, no jobs.
- [Label sponsors workflow run](https://github.com/DCC-EX/CommandStation-EX/actions/runs/31947137990) — `action_required`, no jobs.

Additional validation limits:

- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- Hardware validation — **Not run—no hardware available**. Maintainer bench criteria: flash a supported AVR target from the PR, define representative `SIGNAL`, `SIGNALH`, `SIGNALA`, and `SIGNALAH` automations, verify red/amber/green output and active-low/active-high polarity with the default and alternate maps, and verify synthesized amber on a red+green-only signal.

The PR is ready for maintainer review; hardware bench validation remains outstanding; the exact local five-environment compilation above is complete.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `a9dd06e49e66be3e86acf1560be05028d22abf69`; no hosted code-test result is claimed. Local validation above is the available evidence.
