### PR TITLE
Document platform build matrix

### DIFF
--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -1,0 +1,24 @@
+# Platform support and build matrix
+
+This table describes the platforms that are currently configured and covered by
+the repository's automated compile checks. A successful compile is build
+coverage only; it is not a claim that every board variant has been tested on
+hardware.
+
+| Platform | PlatformIO environment | Board | Arduino / core constraint | CI coverage | Status |
+| --- | --- | --- | --- | --- | --- |
+| AVR | `mega2560` | `megaatmega2560` | Arduino AVR platform selected by PlatformIO | Yes | Supported baseline |
+| ESP32 | `ESP32` | `esp32dev` | `espressif32 @ 6.7.0` (Arduino 2.0.16, ESP-IDF 4.4.7) | Yes | Supported baseline |
+| ESP32-C6 | — | — | No configured environment or validated core/board combination | No | Not supported/validated |
+| RP2040 | — | — | No configured environment in `master` | No | Not supported/validated |
+
+The ESP32 pin is intentional. Issue [#411](https://github.com/DCC-EX/CommandStation-EX/issues/411)
+reports source incompatibilities with Arduino-ESP32 3.0.2, so upgrading the
+core must be treated as a compatibility change and verified separately. Issue
+[#496](https://github.com/DCC-EX/CommandStation-EX/issues/496) requests ESP32-C6
+support, but this repository does not yet have the environment and build
+evidence needed to advertise it.
+
+Pull request [#416](https://github.com/DCC-EX/CommandStation-EX/pull/416) is a
+separate, open early RP2040 implementation and is not replaced or duplicated by
+this matrix.

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -9,6 +9,9 @@ hardware.
 | --- | --- | --- | --- | --- | --- |
 | AVR | `mega2560` | `megaatmega2560` | Arduino AVR platform selected by PlatformIO | Yes | Supported baseline |
 | ESP32 | `ESP32` | `esp32dev` | `espressif32 @ 6.7.0` (Arduino 2.0.16, ESP-IDF 4.4.7) | Yes | Supported baseline |
+| STM32 | `Nucleo-F411RE` | `nucleo_f411re` | `ststm32 @ 19.0.0` | Yes | Supported baseline |
+| STM32 | `Nucleo-F446RE` | `nucleo_f446re` | `ststm32 @ 19.0.0` | Yes | Supported baseline |
+| STM32 | `Nucleo-F429ZI` | `nucleo_f429zi` | `ststm32 @ 19.0.0` | Yes | Experimental Ethernet |
 | ESP32-C6 | — | — | No configured environment or validated core/board combination | No | Not supported/validated |
 | RP2040 | — | — | No configured environment in `master` | No | Not supported/validated |
 


### PR DESCRIPTION
## Scope
Documentation-only addition: `docs/platform-matrix.md` records the configured baseline environments covered by the repository default build, including `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`. It pins the documented ESP32 baseline to `espressif32 @ 6.7.0`, Arduino 2.0.16, ESP-IDF 4.4.7, and board `esp32dev`, and explicitly records ESP32-C6 and RP2040 as not supported or validated by `master`.

The Nucleo rows are included so the matrix matches `platformio.ini` default environments; the compatibility focus remains the ESP32 baseline. This contribution does not change firmware source, `platformio.ini`, installer behavior, board definitions, protocol/API behavior, or hardware support. It does not implement ESP32-C6 or RP2040 support, upgrade the ESP32 core, or duplicate the RP2040 work in PR [#416](https://github.com/DCC-EX/CommandStation-EX/pull/416).

## Related work
- [Issue #411](https://github.com/DCC-EX/CommandStation-EX/issues/411): ESP32 compile errors reported with Arduino-ESP32 3.0.2.
- [Issue #496](https://github.com/DCC-EX/CommandStation-EX/issues/496): ESP32-C6 support request.
- [PR #416](https://github.com/DCC-EX/CommandStation-EX/pull/416): independent early RP2040 implementation; unchanged and not duplicated.
- [Superseded fork-only PR #10](https://github.com/BanjoR/CommandStation-EX/pull/10): replaced by this upstream-targeted PR.

## Validation
- PASS — `git diff --check origin/master...HEAD`.
- PASS — exact changed-file allowlist: only `docs/platform-matrix.md`; no untracked or generated `.pio` output remains.
- PASS — static consistency checks match every default environment listed above, the pinned ESP32 platform/board, issue links, and unsupported C6/RP2040 statements.
- PASS — Markdown table shape check: every matrix row has six columns.
- PASS - exact default `python -m platformio run` on this exact PR head completed for `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`; this PR changes documentation only.
- CI - the upstream PR rollup is empty because the firmware workflow is push-triggered; the exact-head local five-environment matrix above is the available compile evidence.

## Hardware validation
Not run—no hardware available.

Maintainer bench criteria:
1. Run the repository firmware CI build with the checked-in `config.example.h` and confirm the default AVR, ESP32, and Nucleo targets compile.
2. On an `esp32dev`, build and flash using `espressif32 @ 6.7.0` / Arduino 2.0.16 / ESP-IDF 4.4.7, then verify boot, Wi-Fi association, command input, and a basic DCC output/status path.
3. Do not advertise ESP32-C6 or RP2040 support until each has a named PlatformIO environment, pinned core/toolchain, successful CI compile, and hardware bench evidence.