### PR TITLE
Add stable command station identity and connection watchdog

### DIFF
--- a/CommandDistributor.cpp
+++ b/CommandDistributor.cpp
@@ -33,6 +33,7 @@
 #include "StringFormatter.h"
 #include "Websockets.h"
 #include "LocoSlot.h"
+#include <stdlib.h>
 
 // variables to hold clock time
 int16_t lastclocktime;
@@ -60,6 +61,9 @@ template<typename... Targs> void CommandDistributor::broadcastReply(clientType t
   // wifi or ethernet ring streams with multiple client types
   RingStream *  CommandDistributor::ring=0;
 CommandDistributor::clientType  CommandDistributor::clients[MAX_NUM_TCP_CLIENTS]={ NONE_TYPE }; // 0 is and must be NONE_TYPE
+static uint32_t watchdogDeadline[MAX_NUM_TCP_CLIENTS]={0};
+static uint32_t watchdogInterval[MAX_NUM_TCP_CLIENTS]={0};
+static bool watchdogEnabled[MAX_NUM_TCP_CLIENTS]={false};
 
 // Parse is called by Withrottle or Ethernet interface to determine which
 // protocol the client is using and call the appropriate part of dcc++Ex
@@ -71,6 +75,24 @@ void  CommandDistributor::parse(byte clientId,byte * buffer, RingStream * stream
     return;
   }
   ring=stream;
+
+  if (buffer[0]=='<' && buffer[1]=='#') {
+    if (buffer[2]=='>' && watchdogEnabled[clientId]) {
+      watchdogDeadline[clientId]=millis()+watchdogInterval[clientId];
+    } else if (buffer[2]==' ' && buffer[3]=='W' && buffer[4]==' ') {
+      int seconds=atoi((char *)buffer+5);
+      if (seconds>=0 && seconds<=255) {
+        watchdogEnabled[clientId]=(seconds!=0);
+        watchdogInterval[clientId]=seconds*1000UL;
+        watchdogDeadline[clientId]=millis()+watchdogInterval[clientId];
+        if (clients[clientId]==NONE_TYPE) clients[clientId]=COMMAND_TYPE;
+        ring->mark(clientId);
+        StringFormatter::send(stream,F("<# W %d>\n"),seconds);
+        ring->commit();
+        return;
+      }
+    }
+  }
 
   // First check if the client is not known
   // yet and in that case determinine type
@@ -129,8 +151,25 @@ void  CommandDistributor::parse(byte clientId,byte * buffer, RingStream * stream
 void CommandDistributor::forget(byte clientId) {
   if (clients[clientId]==WITHROTTLE_TYPE) WiThrottle::forget(clientId);
   clients[clientId]=NONE_TYPE;
+  watchdogEnabled[clientId]=false;
+  watchdogDeadline[clientId]=0;
+  watchdogInterval[clientId]=0;
   if (virtualLCDClient==clientId) virtualLCDClient=RingStream::NO_CLIENT;
 }
+
+void CommandDistributor::watchdog() {
+  const uint32_t now=millis();
+  for (byte clientId=0; clientId<sizeof(clients); clientId++) {
+    if (watchdogEnabled[clientId] && (int32_t)(now-watchdogDeadline[clientId])>=0) {
+      watchdogEnabled[clientId]=false;
+      watchdogDeadline[clientId]=0;
+      DCC::estopAll();
+      broadcastReply(COMMAND_TYPE,F("<# TIMEOUT %d>\n"),clientId);
+    }
+  }
+}
+#else
+void CommandDistributor::watchdog() {}
 #endif 
 
 // This will not be called on a uno 

--- a/CommandDistributor.h
+++ b/CommandDistributor.h
@@ -60,6 +60,7 @@ public :
   static void broadcastTrackState(const FSH* format,byte trackLetter, const FSH* modename, int16_t dcAddr);
   template<typename... Targs> static void broadcastReply(clientType type, Targs... msg);
   static void forget(byte clientId);
+  static void watchdog();
   static void broadcastRouteState(int16_t routeId,byte state);
   static void broadcastRouteCaption(int16_t routeId,const FSH * caption);
   static void broadcastMessage(char * message);

--- a/CommandStation-EX.ino
+++ b/CommandStation-EX.ino
@@ -154,6 +154,7 @@ void setup()
 
 void loop()
 {
+  CommandDistributor::watchdog();
   #ifdef ENABLE_SERIAL_LOG
     SerialLog.loop();
   #endif

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -82,6 +82,7 @@ Once a new OPCODE is decided upon, update this list.
   Q, Sensor activated
   r, Broadcast address read on programming track
   R, Read CVs
+  i, Server details string; <i> returns stable device identity
   s, Display status
   S, Sensor configuration
   t, Cab/loco update command
@@ -104,6 +105,7 @@ Once a new OPCODE is decided upon, update this list.
 #include "DCCEXParser.h"
 #include "DCC.h"
 #include "DCCWaveform.h"
+#include "DCCTimer.h"
 #include "Turnouts.h"
 #include "Outputs.h"
 #include "Sensors.h"
@@ -721,6 +723,16 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
         CommandDistributor::broadcastPower(); // <s> is the only "get power status" command we have
         Turnout::printAll(stream); //send all Turnout states
         Sensor::printAll(stream);  //send all Sensor  states
+        return;
+
+    case 'i': // DEVICE IDENTITY <i>
+        if (params != 0) break;
+        {
+          byte id[6];
+          DCCTimer::getSimulatedMacAddress(id);
+          StringFormatter::send(stream, F("<iID %02X%02X%02X%02X%02X%02X>\n"),
+            id[0], id[1], id[2], id[3], id[4], id[5]);
+        }
         return;       
 
 #ifndef DISABLE_EEPROM

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -719,6 +719,8 @@ void TrackManager::setJoin(bool joined) {
 #endif
   progTrackSyncMain=joined;
   if (joinRelay!=UNUSED_PIN) digitalWrite(joinRelay,joined?HIGH:LOW);
+  // JOIN changes the effective power topology even when neither driver changed power.
+  CommandDistributor::broadcastPower();
 }
 
 bool TrackManager::isPowerOn(byte t) {

--- a/protocol_tests/test_identity_power_contract.py
+++ b/protocol_tests/test_identity_power_contract.py
@@ -1,0 +1,42 @@
+"""Source-level protocol regression checks for the identity/power contract.
+
+These checks intentionally avoid Arduino dependencies and run in CI before a
+board build is available.
+"""
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class IdentityPowerContractTest(unittest.TestCase):
+    def test_identity_is_an_additive_explicit_query(self):
+        parser = (ROOT / "DCCEXParser.cpp").read_text(encoding="utf-8")
+        self.assertIn("case 'i': // DEVICE IDENTITY <i>", parser)
+        self.assertIn('if (params != 0) break;', parser)
+        self.assertIn('F("<iID %02X%02X%02X%02X%02X%02X>\\n")', parser)
+
+    def test_status_remains_power_and_object_status(self):
+        parser = (ROOT / "DCCEXParser.cpp").read_text(encoding="utf-8")
+        status = parser[parser.index("case 's': // STATUS <s>"):]
+        self.assertIn("CommandDistributor::broadcastPower();", status)
+        self.assertIn("Turnout::printAll(stream);", status)
+        self.assertIn("Sensor::printAll(stream);", status)
+
+    def test_join_has_an_explicit_power_broadcast(self):
+        track = (ROOT / "TrackManager.cpp").read_text(encoding="utf-8")
+        join = track[track.index("void TrackManager::setJoin(bool joined)"):]
+        self.assertIn("CommandDistributor::broadcastPower();", join)
+
+    def test_watchdog_contract_is_connection_local_and_fail_safe(self):
+        distributor = (ROOT / "CommandDistributor.cpp").read_text(encoding="utf-8")
+        self.assertIn('buffer[2]==\' \' && buffer[3]==\'W\'', distributor)
+        self.assertIn('F("<# W %d>\\n")', distributor)
+        self.assertIn('DCC::estopAll();', distributor)
+        self.assertIn('F("<# TIMEOUT %d>\\n")', distributor)
+        self.assertIn('watchdogEnabled[clientId]=false;', distributor)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automatic issue closing

Fixes #505
Fixes #344
Fixes #436

## Summary

Adds backward-compatible, protocol-visible identity and connection/power-state behavior.

- Add `<i>` as an explicit query returning `<iID ...>` with a stable 12-hex-digit device identity; existing `<s>` status behavior remains.
- Add per-network-client `<# W seconds>` watchdog configuration, `<# W 0>` disable, and legacy `<#>` heartbeat feed.
- On expiry, stop all locomotives and broadcast `<# TIMEOUT client>`; clear watchdog state when the client disconnects.
- Broadcast power state after JOIN/unjoin, including when the driver power value itself is unchanged.
- Add dependency-free source-level protocol contract tests.

## Bounded scope

Exact changed files (six):

- `CommandDistributor.cpp`
- `CommandDistributor.h`
- `CommandStation-EX.ino`
- `DCCEXParser.cpp`
- `TrackManager.cpp`
- `protocol_tests/test_identity_power_contract.py`

In scope: the additive `<i>` identity query, per-client watchdog lifecycle/timeout semantics, JOIN/unjoin power-state broadcast, and focused source-level regression coverage.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Authoritative references

- [Issue #505](https://github.com/DCC-EX/CommandStation-EX/issues/505)
- [Issue #451](https://github.com/DCC-EX/CommandStation-EX/issues/451)
- [Issue #344](https://github.com/DCC-EX/CommandStation-EX/issues/344)
- [Issue #436](https://github.com/DCC-EX/CommandStation-EX/issues/436)
- [Superseded fork-only BanjoR PR #12](https://github.com/BanjoR/CommandStation-EX/pull/12) — closed and unmerged; superseded by this upstream PR.

## Tests and checks

Results below are for [head commit `00c3172`](https://github.com/DCC-EX/CommandStation-EX/commit/00c31729f9b75ce6371eaf347dc43b7784e59e96) from an isolated clean clone:

- `python -B -m unittest discover -s protocol_tests -v`: **4/4 passed** (`Ran 4 tests in 0.045s`).
- In-memory Python syntax compilation using `compile(..., 'exec')`: **2/2 Python files passed**; no bytecode was written.
- `git diff --check upstream/master...HEAD`: **passed**.
- Formatting/tool availability: no repository formatter/linter configuration or standalone `clang-format`/`clang-tidy` executable was available; the contribution guide's Google/two-space conventions were manually reviewed.
- Repository gate: upstream `master` is an ancestor; the worktree is clean; the diff is exactly the six files above; no untracked or generated build artifacts remain.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- Exact-head fork CI: PASS - [CI run 31944338767](https://github.com/BanjoR/CommandStation-EX/actions/runs/31944338767) completed successfully for head 00c31729f9b75ce6371eaf347dc43b7784e59e96.
- The upstream firmware workflow is push-triggered, so no pull-request firmware check is attached; the exact-head fork run above is the available hosted build evidence.

This PR is ready for maintainer review; protocol semantics and compatibility surface remain for review.

## Hardware validation

Not run—no hardware available.

Reproducible maintainer bench criteria:

1. Flash each supported target, query `<i>` twice across a reboot, confirm the same board returns the same 12-hex-digit `<iID ...>`, and confirm two different boards do not collide.
2. On one network client, send `<# W 1>` and confirm its acknowledgement; feed `<#>` before one second and confirm no timeout. Stop feeding and confirm `<# TIMEOUT client>` plus locomotive emergency stop. Send `<# W 0>` and confirm the watchdog is disabled; disconnect and reconnect to confirm no stale client watchdog remains.
3. Use two network clients with different watchdog settings to confirm deadlines are connection-local.
4. Toggle JOIN and unjoin while driver power is unchanged and verify a power-state broadcast is emitted; confirm existing `<s>` power and object-status output remains present.