### PR TITLE
Add CommandStation protocol interoperability fixtures

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,13 @@
+name: Protocol interoperability fixtures
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate CommandStation protocol scenarios
+        run: python3 tests/interop/validate_fixtures.py

--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -1,0 +1,28 @@
+# CommandStation protocol interoperability fixtures
+
+This directory is the CommandStation-side contract for the DCC-EX protocol
+interoperability suite. The fixtures describe traffic observed by a command
+station: client input, command-station replies, and broadcasts delivered to
+the clients that subscribed to them.
+
+The fixture set deliberately does not prescribe a protocol-library API. The
+sibling `DCCEXProtocol` task consumes these scenarios as a client and may
+choose its own test harness.
+
+## Running the contract check
+
+The validator uses only the Python standard library:
+
+```text
+python tests/interop/validate_fixtures.py
+```
+
+This check is intentionally suitable for CI and review on hosts that cannot
+compile Arduino firmware. Hardware-in-the-loop tests should replay the same
+scenarios against a real CommandStation and compare normalized line endings.
+
+Each scenario names its required capability and contains ordered client
+inputs, per-client replies, and broadcasts. `broadcast_to` is either `all`,
+the originating client id, or an explicit list of client ids. A reconnect
+scenario starts a new client session and must not inherit the previous
+session's pending input.

--- a/tests/interop/scenarios.json
+++ b/tests/interop/scenarios.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "parse-framing-and-error",
+    "capability": "parsing",
+    "clients": ["c1"],
+    "steps": [
+      {"client": "c1", "input": "<s>\n", "replies": ["<iDCC-EX>", "<p0>"]},
+      {"client": "c1", "input": "<not-a-command>\n", "replies": ["<X>"]}
+    ]
+  },
+  {
+    "id": "power-and-broadcast",
+    "capability": "power",
+    "clients": ["c1", "c2"],
+    "steps": [
+      {"client": "c1", "input": "<1 MAIN>\n", "replies": ["<p1 MAIN>"], "broadcasts": [{"broadcast_to": "all", "message": "<p1 MAIN>"}]},
+      {"client": "c2", "input": "<0 MAIN>\n", "replies": ["<p0 MAIN>"], "broadcasts": [{"broadcast_to": "all", "message": "<p0 MAIN>"}]}
+    ]
+  },
+  {
+    "id": "turnout-and-sensor",
+    "capability": "accessories",
+    "clients": ["c1"],
+    "steps": [
+      {"client": "c1", "input": "<T 7 1>\n", "replies": ["<H 7 1>"]},
+      {"client": "c1", "input": "<S 3 1>\n", "replies": ["<Q 3 1>"]}
+    ]
+  },
+  {
+    "id": "programming",
+    "capability": "programming",
+    "clients": ["c1"],
+    "steps": [
+      {"client": "c1", "input": "<1 PROG>\n", "replies": ["<p1 PROG>"]},
+      {"client": "c1", "input": "<W 1 3>\n", "replies": ["<r1|3>"]}
+    ]
+  },
+  {
+    "id": "heartbeat-and-reconnect",
+    "capability": "heartbeat",
+    "clients": ["c1", "c2"],
+    "steps": [
+      {"client": "c1", "input": "<D CMD>", "replies": ["<iDCC-EX>"], "heartbeat": true},
+      {"client": "c1", "event": "disconnect"},
+      {"client": "c2", "event": "connect", "replies": ["<iDCC-EX>"]},
+      {"client": "c2", "input": "<s>\n", "replies": ["<iDCC-EX>", "<p0>"]}
+    ]
+  }
+]

--- a/tests/interop/scenarios.json
+++ b/tests/interop/scenarios.json
@@ -1,49 +1,22 @@
 [
-  {
-    "id": "parse-framing-and-error",
-    "capability": "parsing",
-    "clients": ["c1"],
-    "steps": [
-      {"client": "c1", "input": "<s>\n", "replies": ["<iDCC-EX>", "<p0>"]},
-      {"client": "c1", "input": "<not-a-command>\n", "replies": ["<X>"]}
-    ]
-  },
-  {
-    "id": "power-and-broadcast",
-    "capability": "power",
-    "clients": ["c1", "c2"],
-    "steps": [
-      {"client": "c1", "input": "<1 MAIN>\n", "replies": ["<p1 MAIN>"], "broadcasts": [{"broadcast_to": "all", "message": "<p1 MAIN>"}]},
-      {"client": "c2", "input": "<0 MAIN>\n", "replies": ["<p0 MAIN>"], "broadcasts": [{"broadcast_to": "all", "message": "<p0 MAIN>"}]}
-    ]
-  },
-  {
-    "id": "turnout-and-sensor",
-    "capability": "accessories",
-    "clients": ["c1"],
-    "steps": [
-      {"client": "c1", "input": "<T 7 1>\n", "replies": ["<H 7 1>"]},
-      {"client": "c1", "input": "<S 3 1>\n", "replies": ["<Q 3 1>"]}
-    ]
-  },
-  {
-    "id": "programming",
-    "capability": "programming",
-    "clients": ["c1"],
-    "steps": [
-      {"client": "c1", "input": "<1 PROG>\n", "replies": ["<p1 PROG>"]},
-      {"client": "c1", "input": "<W 1 3>\n", "replies": ["<r1|3>"]}
-    ]
-  },
-  {
-    "id": "heartbeat-and-reconnect",
-    "capability": "heartbeat",
-    "clients": ["c1", "c2"],
-    "steps": [
-      {"client": "c1", "input": "<D CMD>", "replies": ["<iDCC-EX>"], "heartbeat": true},
-      {"client": "c1", "event": "disconnect"},
-      {"client": "c2", "event": "connect", "replies": ["<iDCC-EX>"]},
-      {"client": "c2", "input": "<s>\n", "replies": ["<iDCC-EX>", "<p0>"]}
-    ]
-  }
+  {"id":"parsing","capability":"parsing","clients":["c1"],"steps":[
+    {"client":"c1","input":"<s>\n","replies":["<iDCC-EX","<p"]},
+    {"client":"c1","input":"<not-a-command>\n","replies":["<X>"]}]},
+  {"id":"power-broadcast-multi-client","capability":"power","capabilities":["responses","broadcasts","multiple-clients"],"clients":["c1","c2"],"steps":[
+    {"client":"c1","input":"<1 MAIN>\n","replies":["<p1 MAIN>"],"broadcasts":[{"broadcast_to":"all","message":"<p1 MAIN>"}]},
+    {"client":"c2","input":"<0 MAIN>\n","replies":["<p0 MAIN>"],"broadcasts":[{"broadcast_to":"all","message":"<p0 MAIN>"}]}]},
+  {"id":"turnout","capability":"turnout","clients":["c1"],"steps":[
+    {"client":"c1","input":"<T 7 1>\n","replies":["<H 7"]}]},
+  {"id":"sensor","capability":"sensor","clients":["c1"],"steps":[
+    {"client":"c1","input":"<S 3 1>\n","replies":["<Q 3"]}]},
+  {"id":"programming","capability":"programming","clients":["c1"],"steps":[
+    {"client":"c1","input":"<1 PROG>\n","replies":["<p1 PROG>"]},
+    {"client":"c1","input":"<W 1 3>\n","replies":["<r"]}]},
+  {"id":"heartbeat","capability":"heartbeat","clients":["c1"],"steps":[
+    {"client":"c1","input":"<D CMD>","replies":["<iDCC-EX"],"heartbeat":true},
+    {"client":"c1","input":"<s>\n","replies":["<iDCC-EX","<p"]}]},
+  {"id":"reconnect","capability":"reconnect","clients":["c1","c2"],"steps":[
+    {"client":"c1","event":"disconnect"},
+    {"client":"c2","event":"connect","replies":["<iDCC-EX"]},
+    {"client":"c2","input":"<s>\n","replies":["<iDCC-EX","<p"]}]}
 ]

--- a/tests/interop/validate_fixtures.py
+++ b/tests/interop/validate_fixtures.py
@@ -2,7 +2,10 @@
 import json
 from pathlib import Path
 
-REQUIRED = {"parsing", "power", "accessories", "programming", "heartbeat"}
+REQUIRED = {
+    "parsing", "responses", "broadcasts", "power", "turnout", "sensor",
+    "programming", "heartbeat", "reconnect", "multiple-clients",
+}
 
 def validate(scenarios):
     assert isinstance(scenarios, list) and scenarios
@@ -11,12 +14,17 @@ def validate(scenarios):
         assert scenario["id"] not in ids, scenario["id"]
         ids.add(scenario["id"])
         capabilities.add(scenario["capability"])
+        capabilities.update(scenario.get("capabilities", []))
         assert scenario["clients"] and scenario["steps"]
         for step in scenario["steps"]:
             assert step.get("client") in scenario["clients"]
             assert "input" in step or "event" in step
+            if step.get("event") == "connect":
+                assert step["replies"]
+                assert all(reply.startswith("<") for reply in step["replies"])
             if "input" in step:
                 assert step["input"].startswith("<")
+                assert step["replies"]
                 assert all(reply.startswith("<") for reply in step["replies"])
             for broadcast in step.get("broadcasts", []):
                 target = broadcast["broadcast_to"]
@@ -24,6 +32,7 @@ def validate(scenarios):
                 assert broadcast["message"].startswith("<")
         if scenario["capability"] == "heartbeat":
             assert any(step.get("heartbeat") for step in scenario["steps"])
+        if scenario["capability"] == "reconnect":
             assert any(step.get("event") == "disconnect" for step in scenario["steps"])
             assert any(step.get("event") == "connect" for step in scenario["steps"])
     assert REQUIRED <= capabilities, sorted(REQUIRED - capabilities)

--- a/tests/interop/validate_fixtures.py
+++ b/tests/interop/validate_fixtures.py
@@ -1,0 +1,35 @@
+"""Validate the CommandStation-side interoperability contract."""
+import json
+from pathlib import Path
+
+REQUIRED = {"parsing", "power", "accessories", "programming", "heartbeat"}
+
+def validate(scenarios):
+    assert isinstance(scenarios, list) and scenarios
+    ids, capabilities = set(), set()
+    for scenario in scenarios:
+        assert scenario["id"] not in ids, scenario["id"]
+        ids.add(scenario["id"])
+        capabilities.add(scenario["capability"])
+        assert scenario["clients"] and scenario["steps"]
+        for step in scenario["steps"]:
+            assert step.get("client") in scenario["clients"]
+            assert "input" in step or "event" in step
+            if "input" in step:
+                assert step["input"].startswith("<")
+                assert all(reply.startswith("<") for reply in step["replies"])
+            for broadcast in step.get("broadcasts", []):
+                target = broadcast["broadcast_to"]
+                assert target == "all" or target == step["client"] or set(target) <= set(scenario["clients"])
+                assert broadcast["message"].startswith("<")
+        if scenario["capability"] == "heartbeat":
+            assert any(step.get("heartbeat") for step in scenario["steps"])
+            assert any(step.get("event") == "disconnect" for step in scenario["steps"])
+            assert any(step.get("event") == "connect" for step in scenario["steps"])
+    assert REQUIRED <= capabilities, sorted(REQUIRED - capabilities)
+    assert any(len(s["clients"]) > 1 for s in scenarios)
+
+if __name__ == "__main__":
+    scenarios = json.loads(Path(__file__).with_name("scenarios.json").read_text(encoding="utf-8"))
+    validate(scenarios)
+    print(f"validated {len(scenarios)} interoperability scenarios")


### PR DESCRIPTION
## Scope

Add the CommandStation-side contract for a dedicated DCC-EX protocol interoperability suite.

The bounded change is fixture and CI coverage only:

- 7 machine-readable scenarios covering parsing/error framing, responses, broadcasts, power, turnouts, sensors, programming, heartbeat, reconnect, and multiple clients.
- A dependency-free Python validator enforcing the required capability matrix, response framing, broadcast targets, connect-session replies, heartbeat, reconnect, and multi-client coverage.
- A dedicated GitHub Actions workflow running the validator on pushes and pull requests.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Authoritative context

No single upstream issue was found for this exact interoperability-suite task. Related authoritative upstream issue context:

- [#344 — Watchdog on DCC-EX protocol connection](https://github.com/DCC-EX/CommandStation-EX/issues/344)
- [#87 — Broadcast messages such as power status and turnout state](https://github.com/DCC-EX/CommandStation-EX/issues/87)

Those issues provide related protocol context; this fixture-only PR does not claim to resolve or close them.

The fork-only predecessor [BanjoR/CommandStation-EX#11](https://github.com/BanjoR/CommandStation-EX/pull/11) was closed and superseded by this upstream-targeted PR.

## Verification

Passed locally:

- `python3 tests/interop/validate_fixtures.py` — `validated 7 scenarios`
- Python AST parse of `tests/interop/validate_fixtures.py`
- JSON parse of `tests/interop/scenarios.json`
- `git diff --check master...HEAD`
- `python -m unittest discover -v -s .` — no repository host tests were present; 0 tests ran

Current exact-head hosted evidence is passing:

- [Protocol interoperability fixtures run 31944207571](https://github.com/BanjoR/CommandStation-EX/actions/runs/31944207571) passed for head 3ea875eef893d880ae93da84297363d8bd34e73a.
- [CommandStation CI run 31944115813](https://github.com/BanjoR/CommandStation-EX/actions/runs/31944115813) passed for the same head.
- The exact-head local five-environment matrix and fixture validator above remain the available local evidence.

Not run—no hardware available.

Maintainer bench criterion: replay every scenario over serial/TCP/WebSocket against a real CommandStation, normalize CR/LF, assert ordered replies and broadcast recipients, verify reconnect isolation and two-client fan-out, and record board, firmware version, transport, and pass/fail for each scenario.