### PR TITLE
Refresh Nucleo-F4 DC-mode timer synchronization

### DIFF
--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -1,6 +1,7 @@
 /*
  *  © 2023 Neil McKechnie
  *  © 2022-2024 Paul M. Antoine
+ *  © 2025 Herb Morton
  *  © 2021 Mike S
  *  © 2021, 2023 Harald Barth
  *  © 2021 Fred Decker
@@ -35,6 +36,21 @@
 #endif
 #include "DIAG.h"
 #include <wiring_private.h>
+
+// DC mode timers enable the PWM signal on select pins.
+// Code added to sync timers which have the same frequency.
+// Function prototypes
+void refreshDCmodeTimers();
+void resetCounterDCmodeTimers();
+
+HardwareTimer *Timer1 = new HardwareTimer(TIM1);
+HardwareTimer *Timer2 = new HardwareTimer(TIM2);
+HardwareTimer *Timer3 = new HardwareTimer(TIM3);
+HardwareTimer *Timer4 = new HardwareTimer(TIM4);
+HardwareTimer *Timer9 = new HardwareTimer(TIM9);
+#if defined(TIM13)
+HardwareTimer *Timer13 = new HardwareTimer(TIM13);
+#endif
 
 #if defined(ARDUINO_NUCLEO_F401RE)
 // Nucleo-64 boards don't have additional serial ports defined by default
@@ -290,7 +306,7 @@ void DCCTimer::DCCEXanalogWriteFrequency(uint8_t pin, uint32_t f) {
   else if (f >= 3)
     DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 16000);
   else if (f >= 2)
-    DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 3400);
+    DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 3600);
   else if (f == 1)
     DCCTimer::DCCEXanalogWriteFrequencyInternal(pin, 480);
   else
@@ -328,7 +344,8 @@ void DCCTimer::DCCEXanalogWriteFrequencyInternal(uint8_t pin, uint32_t frequency
     if (pin_timer[pin] != NULL)
     {
       pin_timer[pin]->setPWM(pin_channel[pin], pin, frequency, 0); // set frequency in Hertz, 0% dutycycle
-      DIAG(F("DCCEXanalogWriteFrequency::Pin %d on Timer Channel %d, frequency %d"), pin, pin_channel[pin], frequency);
+      DIAG(F("DCCEXanalogWriteFrequency::Pin %d on Timer %d Channel %d, frequency %d"), pin, pin_timer[pin], pin_channel[pin], frequency);
+      resetCounterDCmodeTimers();
     }
     else
       DIAG(F("DCCEXanalogWriteFrequency::failed to allocate HardwareTimer instance!"));
@@ -341,6 +358,7 @@ void DCCTimer::DCCEXanalogWriteFrequencyInternal(uint8_t pin, uint32_t frequency
       pinmap_pinout(digitalPinToPinName(pin), PinMap_TIM); // ensure the pin has been configured!
       pin_timer[pin]->setOverflow(frequency, HERTZ_FORMAT); // Just change the frequency if it's already running!
       DIAG(F("DCCEXanalogWriteFrequency::setting frequency to %d"), frequency);
+      resetCounterDCmodeTimers();
     }
   }
   channel_frequency[pin] = frequency;
@@ -365,6 +383,8 @@ void DCCTimer::DCCEXanalogWrite(uint8_t pin, int value, bool invert) {
         pin_timer[pin]->setCaptureCompare(pin_channel[pin], duty_cycle, PERCENT_COMPARE_FORMAT); // DCC_EX_PWM_FREQ Hertz, duty_cycle% dutycycle
         DIAG(F("DCCEXanalogWrite::Pin %d, value %d, duty cycle %d"), pin, value, duty_cycle);
       // }
+      refreshDCmodeTimers();
+      resetCounterDCmodeTimers();
     }
     else
       DIAG(F("DCCEXanalogWrite::Pin %d is not configured for PWM!"), pin);
@@ -659,4 +679,35 @@ void ADCee::begin() {
 #endif
   interrupts();
 }
+
+// NOTE:  additional testing is needed to check the DCC signal 
+//        where the DCC signal pin is a pwm pin on timers 1, 2, 3, 4, 9, 13
+//        or the brake pin is defined on a different timer.
+//        -- example:  F411RE/F446RE - pin 10 on stacked EX8874  
+// lines added to sync timers -- 
+//    not exact sync, but timers with the same frequency should be in sync
+void refreshDCmodeTimers() {
+  Timer1->refresh();
+  Timer2->refresh();
+  Timer3->refresh();
+  Timer4->refresh();
+  Timer9->refresh();
+  #if defined(TIM13)
+  Timer13->refresh();
+  #endif
+}
+
+// Function to synchronize timers - called every time there is powerON commmand for any DC track
+void resetCounterDCmodeTimers() {
+    // Reset the counter for all DC mode timers
+    TIM1->CNT = 0;
+    TIM2->CNT = 0;
+    TIM3->CNT = 0;
+    TIM4->CNT = 0;
+    TIM9->CNT = 0;
+    #if defined(TIM13)
+    TIM13->CNT = 0;
+    #endif
+}
+
 #endif

--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -43,11 +43,21 @@
 void refreshDCmodeTimers();
 void resetCounterDCmodeTimers();
 
+#if defined(TIM1)
 HardwareTimer *Timer1 = new HardwareTimer(TIM1);
+#endif
+#if defined(TIM2)
 HardwareTimer *Timer2 = new HardwareTimer(TIM2);
+#endif
+#if defined(TIM3)
 HardwareTimer *Timer3 = new HardwareTimer(TIM3);
+#endif
+#if defined(TIM4)
 HardwareTimer *Timer4 = new HardwareTimer(TIM4);
+#endif
+#if defined(TIM9)
 HardwareTimer *Timer9 = new HardwareTimer(TIM9);
+#endif
 #if defined(TIM13)
 HardwareTimer *Timer13 = new HardwareTimer(TIM13);
 #endif
@@ -89,7 +99,7 @@ HardwareSerial Serial6(PG9, PG14);  // Rx=PG9, Tx=PG14 -- USART6
 HardwareSerial Serial2(PD6, PD5);  // Rx=PD6, Tx=PD5 -- UART2
 #if !defined(ARDUINO_NUCLEO_F412ZG)  // F412ZG does not have UART5
   HardwareSerial Serial5(PD2, PC12);  // Rx=PD2, Tx=PC12 -- UART5
-#endif  
+#endif
 // Serial3 is defined to use USART3 by default, but is in fact used as the diag console
 // via the debugger on the Nucleo-144. It is therefore unavailable for other DCC-EX uses like WiFi, DFPlayer, etc.
 #else
@@ -687,11 +697,21 @@ void ADCee::begin() {
 // lines added to sync timers -- 
 //    not exact sync, but timers with the same frequency should be in sync
 void refreshDCmodeTimers() {
+#if defined(TIM1)
   Timer1->refresh();
+#endif
+#if defined(TIM2)
   Timer2->refresh();
+#endif
+#if defined(TIM3)
   Timer3->refresh();
+#endif
+#if defined(TIM4)
   Timer4->refresh();
+#endif
+#if defined(TIM9)
   Timer9->refresh();
+#endif
   #if defined(TIM13)
   Timer13->refresh();
   #endif
@@ -700,11 +720,21 @@ void refreshDCmodeTimers() {
 // Function to synchronize timers - called every time there is powerON commmand for any DC track
 void resetCounterDCmodeTimers() {
     // Reset the counter for all DC mode timers
+#if defined(TIM1)
     TIM1->CNT = 0;
+#endif
+#if defined(TIM2)
     TIM2->CNT = 0;
+#endif
+#if defined(TIM3)
     TIM3->CNT = 0;
+#endif
+#if defined(TIM4)
     TIM4->CNT = 0;
+#endif
+#if defined(TIM9)
     TIM9->CNT = 0;
+#endif
     #if defined(TIM13)
     TIM13->CNT = 0;
     #endif

--- a/DCCTimerSTM32.cpp
+++ b/DCCTimerSTM32.cpp
@@ -690,11 +690,11 @@ void ADCee::begin() {
   interrupts();
 }
 
-// NOTE:  additional testing is needed to check the DCC signal 
+// NOTE: additional testing is needed to check the DCC signal
 //        where the DCC signal pin is a pwm pin on timers 1, 2, 3, 4, 9, 13
 //        or the brake pin is defined on a different timer.
-//        -- example:  F411RE/F446RE - pin 10 on stacked EX8874  
-// lines added to sync timers -- 
+//        -- example: F411RE/F446RE - pin 10 on stacked EX8874
+// lines added to sync timers --
 //    not exact sync, but timers with the same frequency should be in sync
 void refreshDCmodeTimers() {
 #if defined(TIM1)

--- a/MotorDriver.cpp
+++ b/MotorDriver.cpp
@@ -1,6 +1,6 @@
 /*
  *  © 2022-2024 Paul M Antoine
- *  © 2024 Herb Morton
+ *  © 2024-2025 Herb Morton
  *  © 2021 Mike S
  *  © 2021 Fred Decker
  *  © 2020-2023 Harald Barth
@@ -371,8 +371,8 @@ void MotorDriver::setDCSignal(byte speedcode, uint8_t frequency /*default =0*/) 
     }
 #endif
     //DIAG(F("Brake pin %d value %d freqency %d"), brakePin, brake, f);
-    DCCTimer::DCCEXanalogWrite(brakePin, brake, invertBrake);
     DCCTimer::DCCEXanalogWriteFrequency(brakePin, f); // set DC PWM frequency
+    DCCTimer::DCCEXanalogWrite(brakePin, brake, invertBrake);  // line swapped to set frequency first
 #else // all AVR here
     DCCTimer::DCCEXanalogWriteFrequency(brakePin, frequency); // frequency steps
     analogWrite(brakePin, invertBrake ? 255-brake : brake);

--- a/MotorDriver.cpp
+++ b/MotorDriver.cpp
@@ -371,8 +371,9 @@ void MotorDriver::setDCSignal(byte speedcode, uint8_t frequency /*default =0*/) 
     }
 #endif
     //DIAG(F("Brake pin %d value %d freqency %d"), brakePin, brake, f);
+    // STM32 allocates the timer in the frequency call; configure it first.
     DCCTimer::DCCEXanalogWriteFrequency(brakePin, f); // set DC PWM frequency
-    DCCTimer::DCCEXanalogWrite(brakePin, brake, invertBrake);  // line swapped to set frequency first
+    DCCTimer::DCCEXanalogWrite(brakePin, brake, invertBrake);
 #else // all AVR here
     DCCTimer::DCCEXanalogWriteFrequency(brakePin, frequency); // frequency steps
     analogWrite(brakePin, invertBrake ? 255-brake : brake);

--- a/Release_Notes/NucleoF4_DC_Timing.md
+++ b/Release_Notes/NucleoF4_DC_Timing.md
@@ -1,0 +1,15 @@
+# Nucleo-F4 DC-mode timing bench criteria
+
+For two adjacent `DC` districts with one address, verify a locomotive crosses
+without a speed step or direction change. Repeat with inverted `DCX` and verify
+the expected polarity and no motion while stopped.
+
+Use a two-channel oscilloscope or logic analyzer to confirm equal PWM frequency,
+common rising-edge phase after power-on, and no sustained phase drift while
+changing speed. Then switch the districts to `MAIN`/DCC and test speed steps,
+stop, emergency stop, and power-cycle; DCC timing and rail behavior must remain
+unchanged.
+
+Repeat with the actual brake/signal pins on each target variant because timer
+mapping differs between Nucleo-F401RE, F411RE, F446RE, and F429ZI. Record board,
+STM32 core, shield, pin mapping, PWM frequency, and capture observations.

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -743,37 +743,3 @@ int16_t TrackManager::returnDCAddr(byte t) {
     return (trackDCAddr[t]);
 }
 
-// Set track power for EACH track, independent of mode
-// This updates the settings so that speed is correct
-// following a frequency change - DC mode
-/* void TrackManager::setTrackPowerF439ZI(byte t) {
-  MotorDriver *driver=track[t];
-  if (driver == NULL) { // track is not defined at all
-   // DIAG(F("Error: Track %c does not exist"), t+'A');
-    return;
-  }
-  TRACK_MODE trackmode = driver->getMode();
-  POWERMODE powermode = driver->getPower();   // line added to enable processing for DC mode tracks
-  POWERMODE oldpower = driver->getPower();
-  //if (trackmode & TRACK_MODE_NONE) {
-  //  driver->setBrake(true);     // Track is unused. Brake is good to have.
-  //  powermode = POWERMODE::OFF; // Track is unused. Force it to OFF
-  //} else
-  if (trackmode & TRACK_MODE_DC) { // includes inverted DC (called DCX)
-    if (powermode == POWERMODE::ON) {
-      driver->setBrake(true);   // DC starts with brake on
-      applyDCSpeed(t);          // speed match DCC throttles
-    }
-  }
-  //else /* MAIN PROG EXT BOOST */ {
-  //  if (powermode == POWERMODE::ON) {
-  //    // toggle brake before turning power on - resets overcurrent error
-  //    // on the Pololu board if brake is wired to ^D2.
-  //    driver->setBrake(true);
-  //    driver->setBrake(false); // DCC runs with brake off
-  //  }
-  //}
-  driver->setPower(powermode);
-  if (oldpower != driver->getPower())
-    CommandDistributor::broadcastPower();
-} */

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -558,19 +558,6 @@ void TrackManager::setTrackPower(TRACK_MODE trackmodeToMatch, POWERMODE powermod
   if (didChange)
     CommandDistributor::broadcastPower();
 
-  // re-initialize DC mode timer settings following powerON  
-  if (powermode == POWERMODE::ON) {  
-    #ifdef ARDUINO_ARCH_STM32
-//        for (byte i=0;i<=lastTrack;i++)  {
-//          setTrackPowerF439ZI(i);
-//        }
-          // repeated in case the <F29..31 was set on a later track than power
-          // Note:  this retains power but prevents speed doubling
-        for (byte i=0;i<lastTrack;i++)  {
-           setTrackPowerF439ZI(i);
-        }
-      #endif
-  }
 }
 
 // Set track power for this track, inependent of mode
@@ -602,19 +589,6 @@ void TrackManager::setTrackPower(POWERMODE powermode, byte t) {
   if (oldpower != driver->getPower())
     CommandDistributor::broadcastPower();
 
-  // re-initialize DC mode timer settings following powerON  
-  if (powermode == POWERMODE::ON) {  
-    #ifdef ARDUINO_ARCH_STM32
-        for (byte i=0;i<=lastTrack;i++)  {
-          setTrackPowerF439ZI(i);
-        }
-          // repeated in case the <F29..31 was set on a later track than power
-          // Note:  this retains power but prevents speed doubling
-        for (byte i=0;i<lastTrack;i++)  {
-           setTrackPowerF439ZI(i);
-        }
-      #endif
-  }
 }
 
 // returns state of the one and only prog track
@@ -769,10 +743,10 @@ int16_t TrackManager::returnDCAddr(byte t) {
     return (trackDCAddr[t]);
 }
 
-// Set track power for EACH track, independent of mode 
+// Set track power for EACH track, independent of mode
 // This updates the settings so that speed is correct
 // following a frequency change - DC mode
-void TrackManager::setTrackPowerF439ZI(byte t) {
+/* void TrackManager::setTrackPowerF439ZI(byte t) {
   MotorDriver *driver=track[t];
   if (driver == NULL) { // track is not defined at all
    // DIAG(F("Error: Track %c does not exist"), t+'A');
@@ -802,4 +776,4 @@ void TrackManager::setTrackPowerF439ZI(byte t) {
   driver->setPower(powermode);
   if (oldpower != driver->getPower())
     CommandDistributor::broadcastPower();
-}
+} */

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -742,4 +742,3 @@ TRACK_MODE TrackManager::getMode(byte t) {
 int16_t TrackManager::returnDCAddr(byte t) {
     return (trackDCAddr[t]);
 }
-

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -758,13 +758,13 @@ int16_t TrackManager::returnDCAddr(byte t) {
   //if (trackmode & TRACK_MODE_NONE) {
   //  driver->setBrake(true);     // Track is unused. Brake is good to have.
   //  powermode = POWERMODE::OFF; // Track is unused. Force it to OFF
-  //} else 
+  //} else
   if (trackmode & TRACK_MODE_DC) { // includes inverted DC (called DCX)
     if (powermode == POWERMODE::ON) {
       driver->setBrake(true);   // DC starts with brake on
       applyDCSpeed(t);          // speed match DCC throttles
     }
-  } 
+  }
   //else /* MAIN PROG EXT BOOST */ {
   //  if (powermode == POWERMODE::ON) {
   //    // toggle brake before turning power on - resets overcurrent error

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -557,6 +557,20 @@ void TrackManager::setTrackPower(TRACK_MODE trackmodeToMatch, POWERMODE powermod
   }
   if (didChange)
     CommandDistributor::broadcastPower();
+
+  // re-initialize DC mode timer settings following powerON  
+  if (powermode == POWERMODE::ON) {  
+    #ifdef ARDUINO_ARCH_STM32
+//        for (byte i=0;i<=lastTrack;i++)  {
+//          setTrackPowerF439ZI(i);
+//        }
+          // repeated in case the <F29..31 was set on a later track than power
+          // Note:  this retains power but prevents speed doubling
+        for (byte i=0;i<lastTrack;i++)  {
+           setTrackPowerF439ZI(i);
+        }
+      #endif
+  }
 }
 
 // Set track power for this track, inependent of mode
@@ -587,6 +601,20 @@ void TrackManager::setTrackPower(POWERMODE powermode, byte t) {
   driver->setPower(powermode);
   if (oldpower != driver->getPower())
     CommandDistributor::broadcastPower();
+
+  // re-initialize DC mode timer settings following powerON  
+  if (powermode == POWERMODE::ON) {  
+    #ifdef ARDUINO_ARCH_STM32
+        for (byte i=0;i<=lastTrack;i++)  {
+          setTrackPowerF439ZI(i);
+        }
+          // repeated in case the <F29..31 was set on a later track than power
+          // Note:  this retains power but prevents speed doubling
+        for (byte i=0;i<lastTrack;i++)  {
+           setTrackPowerF439ZI(i);
+        }
+      #endif
+  }
 }
 
 // returns state of the one and only prog track
@@ -739,4 +767,39 @@ TRACK_MODE TrackManager::getMode(byte t) {
 
 int16_t TrackManager::returnDCAddr(byte t) {
     return (trackDCAddr[t]);
+}
+
+// Set track power for EACH track, independent of mode 
+// This updates the settings so that speed is correct
+// following a frequency change - DC mode
+void TrackManager::setTrackPowerF439ZI(byte t) {
+  MotorDriver *driver=track[t];
+  if (driver == NULL) { // track is not defined at all
+   // DIAG(F("Error: Track %c does not exist"), t+'A');
+    return;
+  }
+  TRACK_MODE trackmode = driver->getMode();
+  POWERMODE powermode = driver->getPower();   // line added to enable processing for DC mode tracks
+  POWERMODE oldpower = driver->getPower();
+  //if (trackmode & TRACK_MODE_NONE) {
+  //  driver->setBrake(true);     // Track is unused. Brake is good to have.
+  //  powermode = POWERMODE::OFF; // Track is unused. Force it to OFF
+  //} else 
+  if (trackmode & TRACK_MODE_DC) { // includes inverted DC (called DCX)
+    if (powermode == POWERMODE::ON) {
+      driver->setBrake(true);   // DC starts with brake on
+      applyDCSpeed(t);          // speed match DCC throttles
+    }
+  } 
+  //else /* MAIN PROG EXT BOOST */ {
+  //  if (powermode == POWERMODE::ON) {
+  //    // toggle brake before turning power on - resets overcurrent error
+  //    // on the Pololu board if brake is wired to ^D2.
+  //    driver->setBrake(true);
+  //    driver->setBrake(false); // DCC runs with brake off
+  //  }
+  //}
+  driver->setPower(powermode);
+  if (oldpower != driver->getPower())
+    CommandDistributor::broadcastPower();
 }

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -1,6 +1,7 @@
 /*
  *  © 2022 Chris Harlow
  *  © 2022-2024 Harald Barth
+ *  © 2025 Herb Morton
  *  © 2023 Colin Murdoch
  *  © 2025 Herb Morton
  * 
@@ -70,6 +71,7 @@ class TrackManager {
     static void setTrackPower(TRACK_MODE trackmode, POWERMODE powermode);
     static void setMainPower(POWERMODE mode) {setTrackPower(TRACK_MODE_MAIN, mode);}
     static void setProgPower(POWERMODE mode) {setTrackPower(TRACK_MODE_PROG, mode);}
+    static void setTrackPowerF439ZI(byte t);
 
     static const int16_t MAX_TRACKS=8;
     static inline int8_t numTracks() { return lastTrack + 1; }

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -71,7 +71,6 @@ class TrackManager {
     static void setTrackPower(TRACK_MODE trackmode, POWERMODE powermode);
     static void setMainPower(POWERMODE mode) {setTrackPower(TRACK_MODE_MAIN, mode);}
     static void setProgPower(POWERMODE mode) {setTrackPower(TRACK_MODE_PROG, mode);}
-    static void setTrackPowerF439ZI(byte t);
 
     static const int16_t MAX_TRACKS=8;
     static inline int8_t numTracks() { return lastTrack + 1; }

--- a/test/host/test_nucleo_f4_dc_timing.py
+++ b/test/host/test_nucleo_f4_dc_timing.py
@@ -1,0 +1,34 @@
+"""Host-only regression checks for the Nucleo-F4 DC timing boundary.
+
+These checks intentionally inspect source contracts; the PWM phase result still
+requires the bench procedure in Release_Notes/NucleoF4_DC_Timing.md.
+"""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).parents[2]
+
+
+class NucleoF4DCTimingContractTests(unittest.TestCase):
+    def test_frequency_is_configured_before_duty(self):
+        source = (ROOT / "MotorDriver.cpp").read_text()
+        block = source[source.index("void MotorDriver::setDCSignal"):]
+        self.assertLess(
+            block.index("DCCEXanalogWriteFrequency(brakePin, f)"),
+            block.index("DCCEXanalogWrite(brakePin, brake, invertBrake)"),
+        )
+
+    def test_timer_registers_are_variant_gated(self):
+        source = (ROOT / "DCCTimerSTM32.cpp").read_text()
+        for timer in ("TIM1", "TIM2", "TIM3", "TIM4", "TIM9"):
+            self.assertIn(f"#if defined({timer})", source)
+
+    def test_no_track_manager_power_replay_for_timing(self):
+        source = (ROOT / "TrackManager.cpp").read_text()
+        self.assertNotIn("re-initialize DC mode timer settings", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## References

- Superseded/related upstream PR: [DCC-EX/CommandStation-EX#452](https://github.com/DCC-EX/CommandStation-EX/pull/452), `NucleoTimerSync for DC mode tracks` (open, targets `devel`).
- No authoritative upstream issue was found for this work in the repository’s issue search; this PR is a bounded refresh of PR #452.

## Scope

This PR is limited to Nucleo-F4/STM32F4 DC-mode PWM timing:

- Synchronize the counters/refresh of available STM32F4 PWM timers used by DC-mode districts.
- Configure DC PWM frequency before duty-cycle allocation.
- Preserve existing DCC behavior by avoiding the superseded PR’s duplicated TrackManager power replay.
- Add host-only source-contract regression tests and maintainer bench criteria.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Validation

- Focused/full available host suite: `python -m unittest discover -s test/host -p test*.py -v` — 3 tests passed.
- Python syntax: focused test parsed successfully with `ast.parse`.
- Static/diff checks: `git diff upstream/master..HEAD --check` — passed; exact six-file allowlist verified; no conflict markers, generated files, or forbidden-scope tokens found.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- Exact-head fork CI: PASS - [CI run 31945247908](https://github.com/BanjoR/CommandStation-EX/actions/runs/31945247908) completed successfully for head c7e3c0710023859e818cc9ef5bd7d1be2d297345.
- The upstream firmware workflow is push-triggered, so no pull-request firmware check is attached; the exact-head fork run above is the available hosted build evidence.

## Hardware validation

Not run—no hardware available.

Maintainer bench criteria are documented in [Release_Notes/NucleoF4_DC_Timing.md](https://github.com/BanjoR/CommandStation-EX/blob/c7e3c0710023859e818cc9ef5bd7d1be2d297345/Release_Notes/NucleoF4_DC_Timing.md). At minimum, on each target Nucleo-F4 variant and actual motor shield:

1. Run two adjacent same-address `DC` districts and verify a locomotive crosses with no speed step or direction change.
2. Repeat with inverted `DCX`, confirming polarity and no motion while stopped.
3. Capture both PWM outputs and verify equal frequency, common rising-edge phase after power-on, and no sustained phase drift during speed changes.
4. Switch to `MAIN`/DCC and test speed steps, stop, emergency stop, and power-cycle; verify DCC timing and rail behavior remain unchanged.
5. Record board variant, STM32 core version, shield, pin mapping, PWM frequency, and oscilloscope/logic-analyzer observations.

This PR is ready for maintainer review; hardware validation remains outstanding. No issue-closing keyword is used because this is a refresh/validation contribution.