### PR TITLE
Centralize portable settings persistence

### DIFF
--- a/EEStore.cpp
+++ b/EEStore.cpp
@@ -43,17 +43,14 @@ void EEStore::init() {
 
   eeStore = (EEStore *)calloc(1, sizeof(EEStore));
 
-  EEPROM.get(0, eeStore->data);  // get eeStore data
+  read(0, eeStore->data);  // get eeStore data
 
   // check to see that eeStore contains valid DCC++ ID
-  if (strncmp(eeStore->data.id, EESTORE_ID, sizeof(EESTORE_ID)) != 0) {  
+  if (!isLegacyEEStoreData(eeStore->data)) {
     // if not, create blank eeStore structure (no
     // turnouts, no sensors) and save it back to EEPROM  
-    strncpy(eeStore->data.id, EESTORE_ID, sizeof(EESTORE_ID)+0);  
-    eeStore->data.nTurnouts = 0;
-    eeStore->data.nSensors = 0;
-    eeStore->data.nOutputs = 0;
-    EEPROM.put(0, eeStore->data);
+    eeStore->data = blankEEStoreData();
+    write(0, eeStore->data);
   }
 
   reset();          // set memory pointer to first free EEPROM space
@@ -71,7 +68,7 @@ void EEStore::clear() {
   eeStore->data.nTurnouts = 0;
   eeStore->data.nSensors = 0;
   eeStore->data.nOutputs = 0;
-  EEPROM.put(0, eeStore->data);
+  write(0, eeStore->data);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -81,8 +78,8 @@ void EEStore::store() {
   Turnout::store();
   Sensor::store();
   Output::store();
-  EEPROM.put(0, eeStore->data);
-  DIAG(F("EEPROM used: %d/%d bytes"), EEStore::pointer(), EEPROM.length());
+  write(0, eeStore->data);
+  DIAG(F("EEPROM used: %d/%d bytes"), EEStore::pointer(), capacity());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -101,7 +98,7 @@ void EEStore::dump(int num) {
   byte b = 0;
   DIAG(F("Addr  0x  char"));
   for (int n = 0; n < num; n++) {
-    EEPROM.get(n, b);
+    read(n, b);
     DIAG(F("%d     %x    %c"), n, b, isprint(b) ? b : ' ');
   }
 }

--- a/EEStore.h
+++ b/EEStore.h
@@ -25,6 +25,7 @@
 #define EEStore_h
 
 #include <Arduino.h>
+#include "EEStoreFormat.h"
 
 #if defined(ARDUINO_ARCH_SAMC)
 #include <SparkFun_External_EEPROM.h>
@@ -33,14 +34,17 @@ extern ExternalEEPROM EEPROM;
 #include <EEPROM.h>
 #endif
 
-#define EESTORE_ID "DCC++1"
-
-struct EEStoreData{
-  char id[sizeof(EESTORE_ID)];
-  uint16_t nTurnouts;
-  uint16_t nSensors;
-  uint16_t nOutputs;
-};
+// A board may define these hooks before including EEStore.h to map persistence
+// to flash, emulated EEPROM, or another addressable backend.
+#ifndef EESTORE_READ
+#define EESTORE_READ(address, value) EEPROM.get(address, value)
+#endif
+#ifndef EESTORE_WRITE
+#define EESTORE_WRITE(address, value) EEPROM.put(address, value)
+#endif
+#ifndef EESTORE_CAPACITY
+#define EESTORE_CAPACITY() EEPROM.length()
+#endif
 
 struct EEStore{
   static EEStore *eeStore;
@@ -53,6 +57,13 @@ struct EEStore{
   static void store();
   static void clear();
   static void dump(int);
+  template <typename T> static void read(int address, T &value) {
+    EESTORE_READ(address, value);
+  }
+  template <typename T> static void write(int address, const T &value) {
+    EESTORE_WRITE(address, value);
+  }
+  static int capacity() { return EESTORE_CAPACITY(); }
 };
 
 #endif

--- a/EEStoreFormat.h
+++ b/EEStoreFormat.h
@@ -1,0 +1,32 @@
+/* Persistent settings format shared by firmware and host tests. */
+#ifndef EEStoreFormat_h
+#define EEStoreFormat_h
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#define EESTORE_ID "DCC++1"
+
+struct EEStoreData {
+  char id[sizeof(EESTORE_ID)];
+  uint16_t nTurnouts;
+  uint16_t nSensors;
+  uint16_t nOutputs;
+};
+
+static_assert(offsetof(EEStoreData, id) == 0, "legacy header must start with id");
+static_assert(sizeof(EEStoreData) == sizeof(EESTORE_ID) + 6,
+              "legacy header layout changed");
+
+inline bool isLegacyEEStoreData(const EEStoreData &data) {
+  return std::memcmp(data.id, EESTORE_ID, sizeof(EESTORE_ID)) == 0;
+}
+
+inline EEStoreData blankEEStoreData() {
+  EEStoreData data{};
+  std::memcpy(data.id, EESTORE_ID, sizeof(EESTORE_ID));
+  return data;
+}
+
+#endif

--- a/EEStoreFormat.h
+++ b/EEStoreFormat.h
@@ -2,9 +2,9 @@
 #ifndef EEStoreFormat_h
 #define EEStoreFormat_h
 
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 #define EESTORE_ID "DCC++1"
 
@@ -20,12 +20,12 @@ static_assert(sizeof(EEStoreData) == sizeof(EESTORE_ID) + 6,
               "legacy header layout changed");
 
 inline bool isLegacyEEStoreData(const EEStoreData &data) {
-  return std::memcmp(data.id, EESTORE_ID, sizeof(EESTORE_ID)) == 0;
+  return memcmp(data.id, EESTORE_ID, sizeof(EESTORE_ID)) == 0;
 }
 
 inline EEStoreData blankEEStoreData() {
   EEStoreData data{};
-  std::memcpy(data.id, EESTORE_ID, sizeof(EESTORE_ID));
+  memcpy(data.id, EESTORE_ID, sizeof(EESTORE_ID));
   return data;
 }
 

--- a/Outputs.cpp
+++ b/Outputs.cpp
@@ -111,7 +111,7 @@ void  Output::activate(uint16_t s){
 #ifndef DISABLE_EEPROM
   // Update EEPROM if output has been stored.    
   if(EEStore::eeStore->data.nOutputs > 0 && num > 0)
-    EEPROM.put(num, data.oStatus);
+    EEStore::write(num, data.oStatus);
 #endif
 }
 
@@ -154,7 +154,7 @@ void Output::load(){
   Output *tt;
 
   for(uint16_t i=0;i<EEStore::eeStore->data.nOutputs;i++){
-    EEPROM.get(EEStore::pointer(),data);
+    EEStore::read(EEStore::pointer(),data);
     // Create new object, set current state to default or to saved state from eeprom.
     tt=create(data.id, data.pin, data.flags);
     uint8_t state = data.setDefault ? data.defaultValue : data.active;
@@ -175,7 +175,7 @@ void Output::store(){
   EEStore::eeStore->data.nOutputs=0;
 
   while(tt!=NULL){
-    EEPROM.put(EEStore::pointer(),tt->data);
+    EEStore::write(EEStore::pointer(),tt->data);
     tt->num=EEStore::pointer() + offsetof(OutputData, oStatus); // Save pointer to flags within EEPROM
     EEStore::advance(sizeof(tt->data));
     tt=tt->nextOutput;

--- a/Sensors.cpp
+++ b/Sensors.cpp
@@ -307,7 +307,7 @@ void Sensor::load(){
 
   uint16_t i=EEStore::eeStore->data.nSensors;
   while(i--){
-    EEPROM.get(EEStore::pointer(),data);
+    EEStore::read(EEStore::pointer(),data);
     tt=create(data.snum, data.pin, data.pullUp);
     EEStore::advance(sizeof(tt->data));
   }
@@ -322,7 +322,7 @@ void Sensor::store(){
   EEStore::eeStore->data.nSensors=0;
 
   while(tt!=NULL){
-    EEPROM.put(EEStore::pointer(),tt->data);
+    EEStore::write(EEStore::pointer(),tt->data);
     EEStore::advance(sizeof(tt->data));
     tt=tt->nextSensor;
     EEStore::eeStore->data.nSensors++;

--- a/Turnouts.cpp
+++ b/Turnouts.cpp
@@ -141,7 +141,7 @@
       // Write byte containing new closed/thrown state to EEPROM if required.  Note that eepromAddress
       // is always zero for LCN turnouts.
       if (EEStore::eeStore->data.nTurnouts > 0 && tt->_eepromAddress > 0) 
-        EEPROM.put(tt->_eepromAddress, tt->_turnoutData.flags);
+        EEStore::write(tt->_eepromAddress, tt->_turnoutData.flags);
 #endif
     }
     return ok;
@@ -170,7 +170,7 @@
     // Read turnout type from EEPROM
     struct TurnoutData turnoutData;
     int eepromAddress = EEStore::pointer() + offsetof(struct TurnoutData, flags); // Address of byte containing the closed flag.
-    EEPROM.get(EEStore::pointer(), turnoutData);
+    EEStore::read(EEStore::pointer(), turnoutData);
     EEStore::advance(sizeof(turnoutData));
 
     switch (turnoutData.turnoutType) {
@@ -264,7 +264,7 @@
 #ifndef DISABLE_EEPROM
     ServoTurnoutData servoTurnoutData;
     // Read class-specific data from EEPROM
-    EEPROM.get(EEStore::pointer(), servoTurnoutData);
+    EEStore::read(EEStore::pointer(), servoTurnoutData);
     EEStore::advance(sizeof(servoTurnoutData));
     
     // Create new object
@@ -300,9 +300,9 @@
     // Write turnout definition and current position to EEPROM
     // First write common servo data, then
     // write the servo-specific data
-    EEPROM.put(EEStore::pointer(), _turnoutData);
+    EEStore::write(EEStore::pointer(), _turnoutData);
     EEStore::advance(sizeof(_turnoutData));
-    EEPROM.put(EEStore::pointer(), _servoTurnoutData);
+    EEStore::write(EEStore::pointer(), _servoTurnoutData);
     EEStore::advance(sizeof(_servoTurnoutData));
 #endif
   }
@@ -354,7 +354,7 @@
 #ifndef DISABLE_EEPROM
     DCCTurnoutData dccTurnoutData;
     // Read class-specific data from EEPROM
-    EEPROM.get(EEStore::pointer(), dccTurnoutData);
+    EEStore::read(EEStore::pointer(), dccTurnoutData);
     EEStore::advance(sizeof(dccTurnoutData));
     
     // Create new object
@@ -391,9 +391,9 @@
     // Write turnout definition and current position to EEPROM
     // First write common servo data, then
     // write the servo-specific data
-    EEPROM.put(EEStore::pointer(), _turnoutData);
+    EEStore::write(EEStore::pointer(), _turnoutData);
     EEStore::advance(sizeof(_turnoutData));
-    EEPROM.put(EEStore::pointer(), _dccTurnoutData);
+    EEStore::write(EEStore::pointer(), _dccTurnoutData);
     EEStore::advance(sizeof(_dccTurnoutData));
 #endif
   }
@@ -437,7 +437,7 @@
 #ifndef DISABLE_EEPROM
     VpinTurnoutData vpinTurnoutData;
     // Read class-specific data from EEPROM
-    EEPROM.get(EEStore::pointer(), vpinTurnoutData);
+    EEStore::read(EEStore::pointer(), vpinTurnoutData);
     EEStore::advance(sizeof(vpinTurnoutData));
     
     // Create new object
@@ -466,9 +466,9 @@
     // Write turnout definition and current position to EEPROM
     // First write common servo data, then
     // write the servo-specific data
-    EEPROM.put(EEStore::pointer(), _turnoutData);
+    EEStore::write(EEStore::pointer(), _turnoutData);
     EEStore::advance(sizeof(_turnoutData));
-    EEPROM.put(EEStore::pointer(), _vpinTurnoutData);
+    EEStore::write(EEStore::pointer(), _vpinTurnoutData);
     EEStore::advance(sizeof(_vpinTurnoutData));
 #endif
   }

--- a/docs/EEPROM-boundary.md
+++ b/docs/EEPROM-boundary.md
@@ -1,0 +1,16 @@
+# Persistent settings boundary
+
+`EEStore` owns the persistent-settings contract. Firmware code must use
+`EEStore::read`, `EEStore::write`, and `EEStore::capacity`; it must not depend
+on a platform's global `EEPROM` object. A future backend may implement those
+operations with EEPROM, flash, emulated flash, or another persistent store.
+
+The first record remains byte-for-byte compatible with existing installations:
+`EEStoreData` starts with the `DCC++1` identifier followed by the three
+16-bit object counts. The record stream following that header is unchanged in
+this phase. A backend must provide Arduino `get`/`put` semantics, including
+the existing address-based layout and capacity reporting.
+
+This boundary deliberately does not redesign the settings protocol or erase
+legacy data. Backend selection and migration can be added independently once a
+target platform supplies a persistent implementation.

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,8 @@ include_dir = .
 
 [env]
 build_flags = -Wall -Wextra
+; Host-only regression sources must not be compiled into firmware targets.
+build_src_filter = +<*> -<tests/>
 ; monitor_filters = time
 
 [env:samd21-dev-usb]

--- a/tests/host_eestore_format.cpp
+++ b/tests/host_eestore_format.cpp
@@ -1,0 +1,22 @@
+#include "../EEStoreFormat.h"
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+int main() {
+  EEStoreData stored = blankEEStoreData();
+  stored.nTurnouts = 3;
+  stored.nSensors = 5;
+  stored.nOutputs = 7;
+
+  std::uint8_t bytes[sizeof(stored)]{};
+  std::memcpy(bytes, &stored, sizeof(stored));
+  EEStoreData loaded{};
+  std::memcpy(&loaded, bytes, sizeof(loaded));
+  assert(isLegacyEEStoreData(loaded));
+  assert(loaded.nTurnouts == 3 && loaded.nSensors == 5 && loaded.nOutputs == 7);
+
+  bytes[0] = 'X';
+  std::memcpy(&loaded, bytes, sizeof(loaded));
+  assert(!isLegacyEEStoreData(loaded));
+}

--- a/tests/host_eestore_format.ps1
+++ b/tests/host_eestore_format.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+# Host regression for the persisted EEStoreData header. The format is:
+# "DCC++1" plus its terminating NUL, then three little-endian uint16 values.
+$id = [Text.Encoding]::ASCII.GetBytes("DCC++1`0")
+$bytes = [byte[]]::new(14)
+[Array]::Copy($id, 0, $bytes, 0, $id.Length)
+[BitConverter]::GetBytes([uint16]3).CopyTo($bytes, 7)
+[BitConverter]::GetBytes([uint16]5).CopyTo($bytes, 9)
+[BitConverter]::GetBytes([uint16]7).CopyTo($bytes, 11)
+
+if ($bytes.Length -ne 14) { throw 'EEStoreData size changed' }
+if ([Text.Encoding]::ASCII.GetString($bytes, 0, 7) -ne "DCC++1`0") {
+  throw 'legacy identifier is not preserved'
+}
+if ([BitConverter]::ToUInt16($bytes, 7) -ne 3 -or
+    [BitConverter]::ToUInt16($bytes, 9) -ne 5 -or
+    [BitConverter]::ToUInt16($bytes, 11) -ne 7) {
+  throw 'legacy counts did not round-trip'
+}
+
+$bytes[0] = [byte][char]'X'
+if ([Text.Encoding]::ASCII.GetString($bytes, 0, 7) -eq "DCC++1`0") {
+  throw 'invalid identifier accepted'
+}
+
+Write-Output 'EEStore host format test passed'


### PR DESCRIPTION
## Summary

This PR defines a platform-neutral persistence boundary for the existing settings store. It is scoped to the persistence access layer and preserves existing settings compatibility.

Related issues:

- [DCC-EX/CommandStation-EX#367](https://github.com/DCC-EX/CommandStation-EX/issues/367)
- [DCC-EX/CommandStation-EX#485](https://github.com/DCC-EX/CommandStation-EX/issues/485)

Superseded fork-only PR: [BanjoR/CommandStation-EX#4](https://github.com/BanjoR/CommandStation-EX/pull/4), now closed in favor of this upstream-targeted PR.

## Bounded scope

- Route existing settings reads, writes, and capacity queries through `EEStore::read`, `EEStore::write`, and `EEStore::capacity`.
- Permit a board-specific backend to provide `EESTORE_READ`, `EESTORE_WRITE`, and `EESTORE_CAPACITY` hooks while retaining Arduino EEPROM behavior by default.
- Preserve the legacy `EEStoreData` byte layout: `DCC++1` identifier plus the three 16-bit object counts.
- Exclude settings migration, a new settings protocol, EEPROM record-stream redesign, automatic data erasure, WiFi credential policy, EXRAIL storage, and any unrelated protocol/traction/integration code.

## Validation

Pass:

- `tests/host_eestore_format.ps1` — passed: `EEStore host format test passed`.
- `python -m platformio run -e mega2560` using isolated task-local PlatformIO directories — passed; firmware linked and produced HEX, RAM 1357/8192 (16.6%), Flash 58190/253952 (22.9%).
- `git diff --check upstream/master...HEAD` — passed.
- Final checkout cleanliness/path audit — passed: clean worktree; only the ten bounded files in the diff; no generated `.pio`, `work`, or `config.h` files; no forbidden/unrelated paths.
- Direct EEPROM access audit — passed: production call sites use the EEStore boundary; the only remaining `EEPROM.*` references are the documented default hook definitions.

- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.

Exact-head fork CI: PASS - [CI run 31951891358](https://github.com/BanjoR/CommandStation-EX/actions/runs/31951891358) completed successfully for head 0a50786c3a5e5c49ff2bc17a9d7ddf3c78f377d6. The upstream PR has no firmware check attached because the main workflow is push-triggered. The C++ host test source contains compile-time layout assertions, but a native host C++ compiler is not installed in this environment; the AVR PlatformIO build validates the shared production format header instead.

## Hardware validation

Not run—no hardware available.

Maintainer bench criteria: build with the intended board configuration; flash a Mega2560 or equivalent EEPROM-backed target; load at least one turnout, sensor, and output; issue `<E>`; power-cycle; verify the same counts and definitions reload; issue `<e>` and verify a subsequent reboot loads an empty store. For a non-EEPROM target, define the board backend hooks and repeat the same round-trip and clear tests, including capacity reporting and preservation of an existing legacy `DCC++1` header.