### PR TITLE
Add accessory decoder PoM writes

### DIFF
--- a/DCC.cpp
+++ b/DCC.cpp
@@ -473,6 +473,22 @@ void DCC::writeCVByteMain(int cab, int cv, byte bValue)  {
   DCCQueue::scheduleDCCPacket(b, nB, 4,cab);
 }
 
+bool DCC::writeAccessoryCVByteMain(int address, byte subaddress, int cv, byte bValue) {
+  if (address < 1 || address > 511 || subaddress > 3 || cv < 1 || cv > 1024)
+    return false;
+  const int linearAddress = (address << 2) | subaddress;
+  byte b[5];
+  b[0] = 0x80 | ((linearAddress >> 2) & 0x3F);
+  b[1] = 0x80 | (((~(linearAddress >> 8)) & 0x07) << 4)
+       | 0x08 | ((linearAddress & 0x03) << 1);
+  const int cvAddress = cv - 1;
+  b[2] = 0xEC | ((cvAddress >> 8) & 0x03);
+  b[3] = cvAddress & 0xFF;
+  b[4] = bValue;
+  DCCQueue::scheduleDCCPacket(b, sizeof(b), 4, linearAddress);
+  return true;
+}
+
 //
 // readCVByteMain: Read a byte with PoM on main.
 // This requires Railcom active 

--- a/DCC.h
+++ b/DCC.h
@@ -61,6 +61,7 @@ public:
   static uint8_t getThrottleFrequency(int cab);
   static bool getThrottleDirection(int cab);
   static void writeCVByteMain(int cab, int cv, byte bValue);
+  static bool writeAccessoryCVByteMain(int address, byte subaddress, int cv, byte bValue);
   static void readCVByteMain(int cab, int cv, ACK_CALLBACK callback);
   
   static void writeCVBitMain(int cab, int cv, byte bNum, bool bValue);

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -46,6 +46,7 @@ Once a new OPCODE is decided upon, update this list.
   0, Track power off
   1, Track power on
   a, DCC accessory control
+  aw, DCC accessory decoder PoM write
   A, DCC extended accessory control
   b, Write CV bit on main
   B, Write CV bit
@@ -303,6 +304,11 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
 #ifndef DISABLE_EEPROM
     (void)EEPROM; // tell compiler not to warn this is unused
 #endif
+    const bool accessoryPom = com[0] == 'a' && com[1] == 'w' && com[2] == ' ';
+    if (accessoryPom) {
+      com[0] = 'w';
+      memmove(com + 1, com + 2, strlen((char *)com + 2) + 1);
+    }
     byte params = 0;
     if (Diag::CMD)
         DIAG(F("PARSING:%s"), com);
@@ -506,6 +512,13 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
 
 #ifndef DISABLE_PROG
     case 'w': // WRITE CV on MAIN <w CAB CV VALUE>
+      if (accessoryPom) {
+        if (params != 4 || p[0] < 1 || p[0] > 511 || p[1] < 0 || p[1] > 3
+            || p[2] < 1 || p[2] > 1024 || p[3] < 0 || p[3] > 255)
+          break;
+        if (DCC::writeAccessoryCVByteMain(p[0], p[1], p[2], p[3])) return;
+        break;
+      }
       if (params != 3)
 	break;
       DCC::writeCVByteMain(p[0], p[1], p[2]);


### PR DESCRIPTION
## Automatic issue closing

Fixes #417
Fixes #467

## Summary

Adds the bounded accessory-decoder Programming on Main (PoM) byte-write command `<aw ADDRESS SUBADDRESS CV VALUE>`.

## Protocol semantics and validation

- `ADDRESS` is the basic accessory decoder address `1..511`, using the same public address model as `<a>`.
- `SUBADDRESS` is the accessory output `0..3`.
- `CV` is the configuration variable number `1..1024`.
- `VALUE` is a byte `0..255`.
- A valid command emits the basic accessory decoder configuration-variable long-form write packet, repeated four times.
- Invalid requests take the normal `<X>` error path and do not queue a packet.
- Existing locomotive `<w CAB CV VALUE>` parsing and programming behavior remains on its original three-parameter path.

For example, `<aw 1 0 1 90>` encodes data bytes `81 F8 EC 00 5A` before the DCC packet framing/checksum.

## Exact scope and exclusions

Changed files are limited to `DCC.cpp`, `DCC.h`, and `DCCEXParser.cpp`.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Related issues and superseded work

- Authoritative issue: [DCC-EX/CommandStation-EX#301](https://github.com/DCC-EX/CommandStation-EX/issues/301)
- Related issue: [DCC-EX/CommandStation-EX#417](https://github.com/DCC-EX/CommandStation-EX/issues/417)
- Related issue: [DCC-EX/CommandStation-EX#467](https://github.com/DCC-EX/CommandStation-EX/issues/467)
- Superseded/incomplete prior PR: [DCC-EX/CommandStation-EX#523](https://github.com/DCC-EX/CommandStation-EX/pull/523), which was based on an older tree and included unrelated changes.

## Validation evidence

- Focused protocol assertions: **PASS** — 3 packet fixtures, 6 invalid address/subaddress/CV boundary cases, byte-range checks, and the legacy three-parameter `<w>` command contract.
- Static source-contract checks: **PASS** — accessory PoM parser recognition, range guards, packet scheduling/repeat count, public API declaration, and preservation of the existing `<w>` call.
- Syntax/compile checks: **PASS** — bundled PlatformIO 6.1.19 compiled all changed translation units in the targeted build and all five default environments in the full build.
- `git diff --check`: **PASS**.
- Changed-file allowlist: **PASS** — exactly `DCC.cpp`, `DCC.h`, and `DCCEXParser.cpp`; checkout status clean after removing only generated PlatformIO state.
- Targeted compile: **PASS** — bundled PlatformIO 6.1.19 `mega2560` build; all changed files compiled and linked.
- Full repository build: **PASS** — `python -m platformio run` using the repository's default matrix: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`; `5 succeeded in 21:41`. The local audit intentionally kept the clean checkout's optional `config.h` absent; the build passed with the repository's expected no-config/motor-shield warnings.
- CI definition inspected: [`.github/workflows/main.yml`](https://github.com/DCC-EX/CommandStation-EX/blob/master/.github/workflows/main.yml), which runs the same PlatformIO build after installing PlatformIO and copying `config.example.h` to `config.h`.
- Upstream PR checks: no checks were reported for this branch at audit time. The repository's main workflow is push-triggered, and the authenticated branch-protection endpoint returned 404, so required-check policy could not be independently confirmed.

## Unavailable checks and hardware limits

- Native unit/integration test suite: **Unavailable — this repository snapshot has no native test target or automated protocol-test harness.** The focused assertions above are not a substitute for a maintained repository test target.
- Formatter/linter: **Unavailable — no formatter or lint tool/configuration was provided by this repository or available in the audit environment.**
- CI result for PR #550: **Unavailable — no upstream check run was reported at audit time.**
- Hardware: **Not run—no hardware available.**

Maintainer bench criteria: connect a known basic accessory decoder with a documented writable CV to a DCC-EX-compatible CommandStation main track; issue a valid `<aw>` command and confirm the decoder changes the selected CV, then confirm a DCC monitor sees `81 F8 EC <CV-1> <VALUE>` for address 1/subaddress 0 with the expected four repeats. Exercise the six invalid boundary classes and confirm `<X>` plus no queued DCC packet. Finally issue an existing locomotive `<w CAB CV VALUE>` command against a test locomotive and confirm its programming behavior is unchanged. No physical result is implied by this PR.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `9a0bb35d5c6cf94732da03a1ebf9c47271480f5c`; no hosted code-test result is claimed. Local validation above is the available evidence.
