### PR TITLE
Respect physical display width when scrolling

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -174,9 +174,12 @@ Display *Display::loop2(bool force) {
           rowFirst = rowCurrent;
 #elif SCROLLMODE==1
           // Scrollmode 1 scrolls by page, so if the last page has just completed then
-          // next time restart with row 0.
+          // next time restart with row 0. Otherwise continue the next page at
+          // the first non-blank row after the page just displayed.
           if (noMoreRowsToDisplay) 
             rowFirst = rowCurrent = 0;
+          else
+            rowFirst = rowCurrent;
 #else
           // Scrollmode 2 scrolls by row.  If the rows don't fit on the screen,
           // then start one row further on next time.  If they do fit, then 

--- a/Display.cpp
+++ b/Display.cpp
@@ -52,6 +52,10 @@ Display::Display(DisplayDevice *deviceDriver) {
   _deviceDriver = deviceDriver;
   // Get device dimensions in characters (e.g. 16x2).
   numScreenColumns = _deviceDriver->getNumCols();
+  // Keep the physical width within the logical row buffer.  Some display
+  // drivers expose more columns than MAX_MSG_SIZE can store.
+  if (numScreenColumns > MAX_CHARACTER_COLS)
+    numScreenColumns = MAX_CHARACTER_COLS;
   numScreenRows = _deviceDriver->getNumRows();
   for (uint8_t row = 0; row < MAX_CHARACTER_ROWS; row++) 
     rowBuffer[row][0] = '\0';
@@ -77,7 +81,9 @@ void Display::_setRow(uint8_t line) {
 }
 
 size_t Display::_write(uint8_t b) {
-  if (hotRow >= MAX_CHARACTER_ROWS || hotCol >= MAX_CHARACTER_COLS) return -1;
+  // The message buffer may be wider than the physical display. Keep writes
+  // within the device row so narrow OLEDs do not wrap into the next row.
+  if (hotRow >= MAX_CHARACTER_ROWS || hotCol >= numScreenColumns) return -1;
   rowBuffer[hotRow][hotCol] = b;
   hotCol++;
   rowBuffer[hotRow][hotCol] = '\0';
@@ -128,7 +134,7 @@ Display *Display::loop2(bool force) {
         buffer[0] = '\0';
       } else {
         // Non-blank line found, so copy it (including terminator)
-        for (uint8_t i = 0; i <= MAX_CHARACTER_COLS; i++)
+        for (uint8_t i = 0; i <= numScreenColumns; i++)
           buffer[i] = rowBuffer[rowCurrent][i];
       }
       _deviceDriver->setRowNative(slot);  // Set position for display
@@ -144,7 +150,7 @@ Display *Display::loop2(bool force) {
         _deviceDriver->writeNative(' ');
       }
 
-      if (++charIndex >= MAX_CHARACTER_COLS) {
+      if (++charIndex >= numScreenColumns) {
         // Screen slot completed, move to next nonblank row
         bufferPointer = 0;
         for (;;) {


### PR DESCRIPTION
## Automatic issue closing

Fixes #427

## Summary

- Bound display writes and refresh pacing to the physical display width.
- Capped physical width at MAX_CHARACTER_COLS so wide display drivers cannot overrun the row buffer.
- Prevented narrow OLED rows from wrapping into subsequent rows.

## References

This is the independently testable display regression slice for [CommandStation issue #427](https://github.com/DCC-EX/CommandStation-EX/issues/427). It is separate from [PR #512](https://github.com/DCC-EX/CommandStation-EX/pull/512), [PR #511](https://github.com/DCC-EX/CommandStation-EX/pull/511), [PR #414](https://github.com/DCC-EX/CommandStation-EX/pull/414), and [issue #383](https://github.com/DCC-EX/CommandStation-EX/issues/383). No superseded BanjoR PR was identified.

## Scope and exclusions

- Only Display.cpp is changed in the validated source branch.
- Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Validation evidence

- Clean task-owned checkout from DCC-EX/CommandStation-EX:master.
- Host/static regression checks and git diff --check passed.
- PASS - Exact default `python -m platformio run` in a clean task checkout with an isolated PlatformIO core completed for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- Exact-head fork CI: PASS - [CI run 31950680704](https://github.com/BanjoR/CommandStation-EX/actions/runs/31950680704) completed successfully for head 8ade964b6ef8010d5cfe254887a147cf28abd572.
- No repository hardware or display runtime was available.

## Hardware validation

Hardware validation: Not run—no hardware available.

Maintainer bench criteria: on each supported display width, exercise scrolling at the narrowest OLED width, the normal character width, and a width above MAX_CHARACTER_COLS; verify no row-buffer overwrite, no wrap into the next row, and unchanged refresh behavior on supported display hardware.

This PR is ready for maintainer review; hardware/display validation remains outstanding; local five-environment compilation is complete.