### PR TITLE
Add opt-in current and fault telemetry

### DIFF
--- a/CommandDistributor.cpp
+++ b/CommandDistributor.cpp
@@ -375,6 +375,12 @@ void  CommandDistributor::broadcastPower() {
   }
 }
 
+void CommandDistributor::broadcastCurrent(byte track, unsigned int milliamps, bool fault) {
+  // Keep the existing <jI> response unchanged.  The three-field form is an
+  // opt-in event: track number, measured current in mA, and fault state.
+  broadcastReply(COMMAND_TYPE, F("<jI %d %d %d>\n"), track, milliamps, fault ? 1 : 0);
+}
+
 void CommandDistributor::broadcastRaw(clientType type, char * msg) {
   broadcastReply(type, F("%s"),msg);
 }

--- a/CommandDistributor.h
+++ b/CommandDistributor.h
@@ -56,6 +56,8 @@ public :
   static void setClockTime(int16_t time, int8_t rate);
   static int16_t retClockTime();
   static void broadcastPower();
+  // Broadcast one current sample for an opt-in <JI 1> telemetry subscriber.
+  static void broadcastCurrent(byte track, unsigned int milliamps, bool fault);
   static void broadcastRaw(clientType type,char * msg);
   static void broadcastTrackState(const FSH* format,byte trackLetter, const FSH* modename, int16_t dcAddr);
   template<typename... Targs> static void broadcastReply(clientType type, Targs... msg);

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -841,6 +841,13 @@ void DCCEXParser::parseOne(Print *stream, byte *com, RingStream * ringStream)
                     return;
                 
                 case "I"_hk: // <JI> current values
+                    if (params==2 && (p[1]==0 || p[1]==1)) {
+                        // <JI 1> enables 10Hz <jI track current fault> events;
+                        // <JI 0> disables them.  A plain <JI> remains the
+                        // established one-shot current query.
+                        TrackManager::setCurrentReporting(p[1] != 0);
+                        return;
+                    }
                     if (params>1) break;
                     TrackManager::reportCurrent(stream);   // <g limit...limit>     
                     return;

--- a/TrackManager.cpp
+++ b/TrackManager.cpp
@@ -45,6 +45,8 @@ int16_t TrackManager::trackDCAddr[MAX_TRACKS] = { 0 };
 int16_t TrackManager::trackPwrMA[MAX_TRACKS] = { 0 };
 
 int8_t TrackManager::lastTrack=-1;
+bool TrackManager::currentReporting=false;
+unsigned long TrackManager::lastCurrentReport=0;
 bool TrackManager::progTrackSyncMain=false; 
 bool TrackManager::progTrackBoosted=false; 
 int16_t TrackManager::joinRelay=UNUSED_PIN;
@@ -515,6 +517,20 @@ void TrackManager::loop() {
     MotorDriver * motorDriver=track[nextCycleTrack];
     bool useProgLimit=dontLimitProg ? false : (bool)(track[nextCycleTrack]->getMode() & TRACK_MODE_PROG);
     motorDriver->checkPowerOverload(useProgLimit, nextCycleTrack);   
+
+    // Current/fault telemetry is deliberately opt-in and throttled.  The
+    // broadcast path is client-safe for Wi-Fi/Ethernet ring streams, unlike
+    // retaining the parser's transient Print pointer.
+    if (currentReporting && (millis() - lastCurrentReport >= 100)) {
+      lastCurrentReport = millis();
+      FOR_EACH_TRACK(t) {
+        if (track[t] == NULL) continue;
+        int current = track[t]->getCurrentRaw(false);
+        bool fault = current < 0 || track[t]->getPower() == POWERMODE::OVERLOAD;
+        if (current < 0) current = -current;
+        CommandDistributor::broadcastCurrent(t, track[t]->raw2mA(current), fault);
+      }
+    }
 }
 
 MotorDriver * TrackManager::getProgDriver() {

--- a/TrackManager.h
+++ b/TrackManager.h
@@ -89,6 +89,7 @@ class TrackManager {
     static void sampleCurrent();
     static void reportGauges(Print* stream);
     static void reportCurrent(Print* stream);
+    static void setCurrentReporting(bool enabled) { currentReporting = enabled; }
     static void reportCurrentLCD(uint8_t display, byte row);
     static void reportObsoleteCurrent(Print* stream); 
     static void streamTrackState(Print* stream, byte t);
@@ -113,6 +114,8 @@ class TrackManager {
     static void addTrack(byte t, MotorDriver* driver);
     static int8_t lastTrack;
     static byte nextCycleTrack;
+    static bool currentReporting;
+    static unsigned long lastCurrentReport;
     static void applyDCSpeed(byte t);
 
     static int16_t trackDCAddr[MAX_TRACKS];  // dc address if TRACK_MODE_DC


### PR DESCRIPTION
## Authoritative references

- Upstream reference: [DCC-EX/CommandStation-EX#260](https://github.com/DCC-EX/CommandStation-EX/pull/260), the stale/incomplete current-measurement proposal being refreshed.
- Superseded fork-only publication: [BanjoR/CommandStation-EX#3](https://github.com/BanjoR/CommandStation-EX/pull/3).

## Bounded scope

This refresh changes exactly five source files:

- `CommandDistributor.cpp` / `CommandDistributor.h`: add a client-safe current/fault broadcast using the existing `CommandDistributor` path.
- `DCCEXParser.cpp`: add opt-in `<JI 1>` and `<JI 0>` controls while preserving the existing plain `<JI>` query.
- `TrackManager.cpp` / `TrackManager.h`: add disabled-by-default, 100 ms-throttled telemetry from existing current and overload/fault state.

When enabled, events use `<jI TRACK CURRENT_MA FAULT>` with zero-based track number, measured milliamps, and `0`/`1` fault state. The implementation is opt-in and broadcasts through the client-safe distributor rather than retaining the parser's transient Wi-Fi/Ethernet stream.

Explicit exclusions:

- No change to the established plain `<JI>` response.
- No new `<A>` or `<a>` protocol command and no internal RMS/history-buffer design.
- No motor-shield calibration changes.
- No global diagnostic default changes or GPIO instrumentation.
- No hardware, vendor, protocol, integration, or unrelated subsystem changes.

## Validation

All results below refer to head commit [`37cda773`](https://github.com/DCC-EX/CommandStation-EX/commit/37cda773ff695da09f23ffa8e551e90650266b57).

- PASS — `git diff --check`.
- PASS — clean-worktree, live upstream-ancestry, five-file allowlist, line-ending, generated-artifact, and forbidden-change checks.
- PASS — focused host assertions covering `<JI>` backward compatibility, `<JI 1>/<JI 0>` gating, `<jI>` event formatting, default-disabled state, 100 ms throttling, current/fault sources, and safe broadcast routing.
- PASS - the exact default PlatformIO matrix on this branch completed successfully for all five configured environments: `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- CI unavailable in the upstream PR context because the firmware workflow is push-triggered; the exact local five-environment matrix above passed. Ancillary Docs and Label runs are not firmware validation results.
- Host-side Ztest execution is not available in this repository; the exact firmware matrix above passed, but hardware/runtime coverage remains maintainer-only.

## Hardware validation

Not run—no hardware available.

Maintainer bench criteria:

1. Build and flash the validated firmware with a supported motor shield and a configured current-sense/fault-pin setup.
2. Connect a command client, issue `<JI 1>`, and verify nominal approximately-100-ms `<jI TRACK CURRENT_MA 0>` events for every active track, with the reported milliamps matching an independent meter or known load within the board's expected accuracy.
3. Trigger a supported fault-pin or overload condition and verify the affected track reports `<jI TRACK CURRENT_MA 1>` and enters the existing overload state; clear the condition and verify recovery behavior.
4. Issue `<JI 0>` and verify asynchronous events stop, while a plain `<JI>` still returns the established one-shot current response.
5. Repeat with Wi-Fi/Ethernet clients and multiple clients to confirm broadcasts do not corrupt or cross-contaminate client buffers.

This pull request is ready for maintainer review; hardware validation remains outstanding; local firmware compilation is complete.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `37cda773ff695da09f23ffa8e551e90650266b57`; no hosted code-test result is claimed. Local validation above is the available evidence.
