### PR TITLE
Add EXRAIL function and acquisition events

### DIFF
--- a/DCC.cpp
+++ b/DCC.cpp
@@ -298,6 +298,9 @@ bool DCC::setFn( int cab, int16_t functionNumber, bool on) {
     if (functionNumber <= 28)
       updateGroupflags(slot, functionNumber);
     CommandDistributor::broadcastLoco(slot);
+#ifdef EXRAIL_ACTIVE
+    RMFT2::functionEvent(cab, functionNumber);
+#endif
   }
   return true;
 }

--- a/EXRAIL2.cpp
+++ b/EXRAIL2.cpp
@@ -90,6 +90,8 @@ LookList *  RMFT2::onClockLookup=NULL;
 LookList *  RMFT2::onRotateLookup=NULL;
 #endif
 LookList *  RMFT2::onOverloadLookup=NULL;
+LookList *  RMFT2::onFunctionLookup=NULL;
+LookList *  RMFT2::onAcquireLookup=NULL;
 LookList *  RMFT2::onBlockEnterLookup=NULL;
 LookList *  RMFT2::onBlockExitLookup=NULL;
 #ifdef BOOSTER_INPUT
@@ -211,6 +213,8 @@ LookList* RMFT2::LookListLoader(OPCODE op1, OPCODE op2, OPCODE op3) {
   onRotateLookup=LookListLoader(OPCODE_ONROTATE);
 #endif
   onOverloadLookup=LookListLoader(OPCODE_ONOVERLOAD);
+  onFunctionLookup=LookListLoader(OPCODE_ONFUNCTION);
+  onAcquireLookup=LookListLoader(OPCODE_ONACQUIRE);
 
   if (compileFeatures & FEATURE_BLOCK) {
     onBlockEnterLookup=LookListLoader(OPCODE_ONBLOCKENTER);
@@ -1316,6 +1320,8 @@ void RMFT2::loop2() {
   case OPCODE_ONLCC:   // LCC event catchers ignored here 
   case OPCODE_ONACON:   // MERG event catchers ignored here 
   case OPCODE_ONACOF:   // MERG event catchers ignored here 
+  case OPCODE_ONFUNCTION:
+  case OPCODE_ONACQUIRE:
   case OPCODE_ONTHROW:
   case OPCODE_ONACTIVATE: // Activate event catchers ignored here
   case OPCODE_ONDEACTIVATE:
@@ -1542,6 +1548,14 @@ void RMFT2::blockEvent(int16_t block, int16_t loco, bool entering) {
 void RMFT2::changeEvent(int16_t vpin, bool change) {
   // Hunt for an ONCHANGE for this sensor
   if (change)  onChangeLookup->handleEvent(F("CHANGE"),vpin);
+}
+
+void RMFT2::functionEvent(int16_t cab, int16_t functionNumber) {
+  onFunctionLookup->handleEvent(F("FUNCTION"),functionNumber,cab);
+}
+
+void RMFT2::acquireEvent(int16_t cab) {
+  onAcquireLookup->handleEvent(F("ACQUIRE"),cab,cab);
 }
 
 #ifndef IO_NO_HAL

--- a/EXRAIL2.h
+++ b/EXRAIL2.h
@@ -74,6 +74,7 @@ enum OPCODE : byte {OPCODE_THROW,OPCODE_CLOSE,OPCODE_TOGGLE_TURNOUT,
              OPCODE_LCC,OPCODE_LCCX,OPCODE_ONLCC,
              OPCODE_ACON, OPCODE_ACOF, 
              OPCODE_ONACON, OPCODE_ONACOF, 
+             OPCODE_ONFUNCTION, OPCODE_ONACQUIRE,
              OPCODE_ONOVERLOAD,
 	     OPCODE_ONRAILSYNCON,OPCODE_ONRAILSYNCOFF,
              OPCODE_ROUTE_ACTIVE,OPCODE_ROUTE_INACTIVE,OPCODE_ROUTE_HIDDEN,
@@ -207,6 +208,8 @@ class LookList {
     static void clockEvent(int16_t clocktime, bool change);
     static void rotateEvent(int16_t id, bool change);
     static void powerEvent(int16_t track, bool overload);
+    static void functionEvent(int16_t cab, int16_t functionNumber);
+    static void acquireEvent(int16_t cab);
 #ifdef BOOSTER_INPUT
     static void railsyncEvent(bool on);
 #endif
@@ -282,6 +285,8 @@ private:
    static LookList * onRotateLookup;
 #endif
    static LookList * onOverloadLookup;
+   static LookList * onFunctionLookup;
+   static LookList * onAcquireLookup;
    static LookList * onBlockEnterLookup;
    static LookList * onBlockExitLookup;
 #ifdef BOOSTER_INPUT

--- a/EXRAIL2MacroBase.h
+++ b/EXRAIL2MacroBase.h
@@ -455,6 +455,14 @@
 #define ONACOF(eventid)
 ///brief Start task here when ACOF for event received from MERG CBUS
 
+#define ONFUNCTION(func)
+///brief Start task when the given loco function changes state.
+///param func function number
+
+#define ONACQUIRE(cab)
+///brief Start task when a throttle acquires the given loco.
+///param cab loco id
+
 #define ONACTIVATE(addr,subaddr)
 ///brief Start task here when DCC Activate sent for short address
 

--- a/EXRAIL2MacroReset.h
+++ b/EXRAIL2MacroReset.h
@@ -126,6 +126,8 @@
 #undef ACOF
 #undef ONACON
 #undef ONACOF
+#undef ONFUNCTION
+#undef ONACQUIRE
 #undef MESSAGE
 #undef ONACTIVATE
 #undef ONACTIVATEL

--- a/EXRAILMacros.h
+++ b/EXRAILMacros.h
@@ -617,6 +617,8 @@ int RMFT2::onLCCLookup[RMFT2::countLCCLookup];
 #define ACOF(eventid) OPCODE_ACOF,V(((uint32_t)eventid >>16) & 0xFFFF),OPCODE_PAD,V(eventid & 0xFFFF),
 #define ONACON(eventid) OPCODE_ONACON,V((uint32_t)(eventid) >>16),OPCODE_PAD,V(eventid & 0xFFFF),
 #define ONACOF(eventid) OPCODE_ONACOF,V((uint32_t)(eventid) >>16),OPCODE_PAD,V(eventid & 0xFFFF),
+#define ONFUNCTION(func) OPCODE_ONFUNCTION,V(func),
+#define ONACQUIRE(cab) OPCODE_ONACQUIRE,V(cab),
 #define LCD(id,msg) PRINT(msg)
 #define SCREEN(display,id,msg) PRINT(msg)
 #define STEALTH(code...) PRINT(dummy)

--- a/EXRAILTest.h
+++ b/EXRAILTest.h
@@ -199,6 +199,30 @@ ROUTE(8001,"8001 ESTOP_RESUME test")
    ZTEST("<D CABS>",DCC::getLocoSpeedByte(3)==(128+20))
    DONE
 
+// Test parser-triggered ONFUNCTION events and suppression of unchanged states.
+ROUTE(8020,"8020 ONFUNCTION parser test")
+   SETLOCO(3)
+   FOFF(4)
+   ZTEST("<F 3 3 1>",DCC::getFn(3,3)==1)
+   DELAY(100)
+   ZTEST("ONFUNCTION ON",DCC::getFn(3,4)==1)
+   ZTEST("<F 3 3 1>",DCC::getFn(3,3)==1)
+   DELAY(100)
+   ZTEST("ONFUNCTION unchanged",DCC::getFn(3,4)==1)
+   ZTEST("<F 3 3 0>",DCC::getFn(3,3)==0)
+   DELAY(100)
+   ZTEST("ONFUNCTION OFF",DCC::getFn(3,4)==0)
+   DONE
+
+ONFUNCTION(3)
+   FTOGGLE(4)
+   DONE
+
+// Compile/runtime coverage for cab-specific acquisition tuning.
+ONACQUIRE(3)
+   MOMENTUM(30)
+   DONE
+
 
 #define MYGROUP 1,2,3,4   
 ROUTE(1771,"1771 Test IFLOCO with multiple loco ids")

--- a/WiThrottle.cpp
+++ b/WiThrottle.cpp
@@ -280,6 +280,9 @@ void WiThrottle::multithrottle(RingStream * stream, byte * cmd){
 	      myLocos[loco].functionMap=DCC::getFunctionMap(locoid); 
 	      myLocos[loco].broadcastPending=true; // means speed/dir will be sent later
 	      mostRecentCab=locoid;
+#ifdef EXRAIL_ACTIVE
+      RMFT2::acquireEvent(locoid);
+#endif
 	      StringFormatter::send(stream, F("M%c+%c%d<;>\n"), throttleChar, cmd[3] ,locoid); //tell client to add loco
 	      sendFunctions(stream,loco);
 	      //speed and direction will be published at next broadcast cycle


### PR DESCRIPTION
## Automatic issue closing

Fixes #475
Fixes #464

## Summary

Adds two EXRAIL event macros with cab-aware task context:

- ONFUNCTION(func) starts a task when the specified DCC function changes state.
- ONACQUIRE(cab) starts a task after a WiThrottle cab has been successfully acquired.

This is the bounded implementation in [commit 25237a5](https://github.com/BanjoR/CommandStation-EX/commit/25237a5652aa5a970aa80a8e5799d8c5fd6e6bc7).

## References

- [Issue #475 - EXRAIL ONFUNCTION handler](https://github.com/DCC-EX/CommandStation-EX/issues/475)
- [Issue #464 - Allow for loco tuning ONACQUIRE](https://github.com/DCC-EX/CommandStation-EX/issues/464)
- Superseded PRs: none found by the repository PR search for these issues, event names, or this head branch. This PR does not replace a healthy existing PR.

## Bounded scope

- ONFUNCTION(func) is indexed by function number and is dispatched from the real DCC::setFn state transition, after the existing loco broadcast. It runs for both on and off transitions, once only when the stored function bit changes; unchanged requests do not dispatch. The event task receives the cab as its loco context.
- ONACQUIRE(cab) is indexed by cab and is dispatched only after WiThrottle has obtained the command-station slot and assigned the cab to a client M+ entry. Drive-away acquisition M+* re-enters the same successful path. The event task receives that cab as its loco context.
- EXRAIL opcode declarations, macro base/reset coverage, RouteCode emission, runtime lookup loading, ignored-catcher handling, and the embedded EXRAILTest.h fixture are included.

## Explicit exclusions

- No ONFON/ONFOFF API, new parser syntax, or protocol change.
- No event on failed slot acquisition, a client-list capacity failure, or WiThrottle release M-.
- No decoder-sniffer event, hardware behavior claim, SPEEDLIMIT implementation, unrelated refactor, or content from outside this task's allowlist.

## Validation evidence

Passed:

- Focused structural regression: static_gate_exit=0; verifies macro signatures/reset/codegen, opcode declarations, lookup dispatch, parser-to-DCC::setFn reachability, post-broadcast transition placement, success-only acquisition placement, embedded fixture coverage, git diff --check, and the exact eight-file allowlist.
- Embedded compile/runtime fixture coverage: EXRAILTest.h route 8020 exercises parser function on/off transitions and unchanged-state suppression; ONACQUIRE(3) compiles cab-specific acquisition tuning.
- git diff --check: pass; git fsck --full --no-progress: pass; clean status and no untracked/generated files at publication.
- Inactive/configless mega2560 PlatformIO build-size check: pass - 58,170 program bytes (22.2%), 1,357 data bytes (16.6%).
- EXRAIL-active temporary-fixture mega2560 build-size check: pass - 78,289 program bytes (29.9%), 1,768 data bytes (21.6%). The temporary myAutomation.h was removed and is not part of this commit.
- Exact default PlatformIO matrix: PASS - all five configured environments completed successfully: mega2560, ESP32, Nucleo-F411RE, Nucleo-F446RE, and Nucleo-F429ZI.
- Exact-head fork CI: PASS - [CI run 31952477982](https://github.com/BanjoR/CommandStation-EX/actions/runs/31952477982), including the Compile Command Station (AVR) job, completed successfully for head 25237a5652aa5a970aa80a8e5799d8c5fd6e6bc7.
- Upstream PR status: no firmware check is attached because the repository CI workflow is push-triggered; the successful fork run above is the available exact-head firmware result.
- Host pytest suite: no repository tests were collected; no host test target is present in the tracked checkout.

## Resource impact

- Each ONFUNCTION or ONACQUIRE declaration emits one existing three-byte EXRAIL opcode/operand entry.
- Runtime uses the existing LookList lookup model: two additional lookup objects/pointers are loaded; each matching handler uses the existing pair of int16_t lookup/result entries plus allocator overhead. No per-event state table or feature bit is added.
- The active fixture measurements above include the existing EXRAILTest.h workload, so they are build-size evidence, not an isolated source-only delta. Exact maintainer CI comparison against the project baseline remains the final resource check.

## Hardware validation

Not run - no hardware is available. Maintainer bench criteria: acquire a valid cab through direct WiThrottle M+S/L and drive-away M+*; verify ONACQUIRE(cab) applies the handler before the next control action, failed acquisition and M- produce no event, and parser/WiThrottle function transitions produce exactly one ONFUNCTION(func) task per stored on/off transition while existing loco broadcasts remain present.

## PR state

Ready for review. Target: DCC-EX/CommandStation-EX:master. Head: BanjoR/CommandStation-EX:codex/commandstation-exrail-functions.