### PR TITLE
Document and test RailCom block locomotive context

### DIFF
--- a/EXRAIL2MacroBase.h
+++ b/EXRAIL2MacroBase.h
@@ -299,6 +299,9 @@
 #define IFLOCO(loco_id_list...)
 ///brief Checks if current task loco is in the list of loco ids. List may be comma separated values
 ///see IF
+///note In an ONBLOCKENTER or ONBLOCKEXIT handler, the current task loco is the
+///note locomotive ID supplied by the RailCom block event. This allows a handler
+///note to test or dispatch on the locomotive without maintaining a second block table.
 
 #define IFLT(vpin,value)
 ///brief Checks if analog sensor < value
@@ -467,10 +470,12 @@
 #define ONBLOCKENTER(block_id)
 ///brief Start task here when a loco enters a railcom block
 ///param block_id vpin associated to block by HAL(I2CRailcom..)
+///note The handler task's current loco is the RailCom locomotive ID.
 
 #define ONBLOCKEXIT(block_id)
 ///brief Start task here when a loco leaves a railcom block
 ///param block_id vpin associated to block by HAL(I2CRailcom..)
+///note The handler task's current loco is the RailCom locomotive ID.
 
 #define ONTIME(minute_in_day)
 ///brief Start task here when fastclock matches

--- a/EXRAILTest.h
+++ b/EXRAILTest.h
@@ -257,6 +257,17 @@ ROUTE(1771,"1771 Test IFLOCO with multiple loco ids")
   
 
 
+// RailCom block events start their handler with the detected locomotive ID.
+// Keep this coverage outside route 1771 so it is a separate event handler.
+AUTOMATION(1772,"1772 Test RailCom block loco context")
+  ONBLOCKENTER(1700)
+    IFLOCO(42)
+      PRINT("RailCom block loco context passed")
+    ELSE
+      PRINT("RailCom block loco context failed")
+    ENDIF
+  DONE
+
 // Speedometer example
 // Track is =TS1===TS2===TS3= timing between S2 and S3.
 


### PR DESCRIPTION
## Summary

This PR addresses the evidence and compatibility portion of [DCC-EX/CommandStation-EX issue #470](https://github.com/DCC-EX/CommandStation-EX/issues/470), whose current body is empty and which has no comments or acceptance criteria.

The existing RailCom path already extracts the locomotive ID and passes it into the EXRAIL block-event task. This bounded change documents that contract and adds compile-time EXRAIL coverage:

- Clarify that `IFLOCO(...)` in an `ONBLOCKENTER` or `ONBLOCKEXIT` handler tests the locomotive ID supplied by the RailCom block event.
- Clarify the locomotive context for `ONBLOCKENTER` and `ONBLOCKEXIT`.
- Add `AUTOMATION(1772)` coverage that compiles an `ONBLOCKENTER(1700)` handler and checks `IFLOCO(42)`, outside the existing route 1771.

No RailCom parser, event-dispatch, hardware-driver, persistent block-table, opcode, or protocol behavior is changed.

## Authoritative issue and related work

- Authoritative issue: [#470 — EXRAIL IF railcom block occupied, and setloco to loco in block](https://github.com/DCC-EX/CommandStation-EX/issues/470)
- Superseded or duplicate PRs: none found in the live repository and branch searches.
- [PR #455 — Add Railcom cutout to STM32 platform](https://github.com/DCC-EX/CommandStation-EX/pull/455) is unrelated STM32 cutout work and is not superseded by this PR.

## Exact bounded scope

Changed paths are exactly:

- `EXRAIL2MacroBase.h`
- `EXRAILTest.h`

Included behavior is limited to the EXRAIL documentation contract and compile-time regression coverage described above.

Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Validation evidence

Passed:

- Repository boundary: task-local root only; `origin` is `BanjoR/CommandStation-EX`, `upstream` is `DCC-EX/CommandStation-EX`; both live repositories report default branch `master`.
- Ancestry: `HEAD=3da3500712e759f0db094d97954c863f6351022b`, parent and upstream/master base `0ad3080bd94949c75fd4824f54ae792bd990886b`; no upstream push was performed.
- Changed-file allowlist: exactly the two paths above; no untracked or generated files remain.
- EXRAIL macro coverage: the existing RailCom path passes `locoid` into `RMFT2::blockEvent`, the block handler starts with that loco context, and the new `AUTOMATION(1772)` compiles `ONBLOCKENTER(1700)` with `IFLOCO(42)`.
- Static/diff checks: `git diff --check`, `git diff --cached --check`, `git show --check`, `git fsck --full --no-progress`, and exact-path checks all passed.
- Default firmware build: PASS - the exact default PlatformIO matrix completed successfully for `mega2560`, `ESP32`, `Nucleo-F411RE`, `Nucleo-F446RE`, and `Nucleo-F429ZI`.
- Focused EXRAIL compile harness: `mega2560`, passed; 1,766/8,192 bytes RAM (21.6%) and 77,987/253,952 bytes flash (30.7%). The temporary harness and build/cache outputs were removed afterward. These are whole-configuration measurements, not an attribution of the size difference solely to the added lines.
- Upstream base CI: the latest successful [upstream master CI run](https://github.com/DCC-EX/CommandStation-EX/actions/runs/29987346960) passed the AVR compile for base commit `0ad3080`. This is base evidence, not a result for this fork PR head.

Validation limits:

- Host suite: `python -m unittest discover -v` ran 0 tests; this snapshot has no native host test suite or CMake test target.
- Full PlatformIO matrix: PASS - the five-environment result above covers the repository default build matrix.
- Exact-head fork CI: PASS - [CI run 31953020825](https://github.com/BanjoR/CommandStation-EX/actions/runs/31953020825) completed successfully for head 3da3500712e759f0db094d97954c863f6351022b; it is the available firmware CI result.
- Upstream PR status: no pull-request firmware check is attached because the main workflow is push-triggered; ancillary workflow runs are not treated as firmware evidence. Required-check inventory was not independently available because the branch-protection endpoint returned HTTP 403.
- Formatting/static tools: `clang-format`, `clang-tidy`, `cppcheck`, `astyle`, and `doxygen` were not installed; `git diff --check` passed.

## Hardware validation

Not run—no hardware available.

Maintainer bench criteria: on a supported Mega/EX8874 setup, configure `HAL(I2CRailcom,10000,32,0x08)`, enable `<C RAILCOM ON>`, exercise a real RailCom collector with known locomotive IDs entering and leaving mapped blocks, and verify `ONBLOCKENTER(10000)`/`ONBLOCKEXIT(10000)` receive the expected current loco for `IFLOCO` and any intended `SETLOCO` use. Also exercise the documented serial simulations `<K 10000 42>` and `<k 10000 42>`, plus multi-loco transitions. No physical test result is implied by this PR.

This PR is ready for maintainer review; remaining review covers the specification, CI/bench validation, and any follow-up behavior requested for the underspecified issue. No issue-closing keyword is used.